### PR TITLE
Add minimal CI workflow (npm ci + npm test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
Closes #36

## What
- `.github/workflows/ci.yml` — runs on push + PR to `main`: checkout, setup-node@v4 (node 22, npm cache), `npm ci`, `npm test`.

## Why
The critic's auto-merge guardrail (tier 1/2) needs `gh pr checks` green before merging. With no workflow, `gh pr checks` returns "no checks reported" — filed as #36 during PR #35 review. This unblocks guarded auto-merge as the builder earns autonomy.

## Verify
- YAML valid; minimal (no build/deploy/matrix).
- `npm ci` works (lockfile committed in #31).
- `npm test` is the same 2 tests already passing locally.

## Risk
Low. No secrets. No deploy. Cache uses `setup-node`'s built-in npm cache (safe).
