### PR TITLE
SQLite storage layer (node:sqlite) + schema + tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ SESSION_SECRET=           # Express session signing key (random string)
 
 # --- Optional (with defaults) ---
 PORT=3000
+PULSE_DB_PATH=data/pulse.sqlite
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=gemma4:e4b
 BRIEFING_TIME=07:00

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,0 +1,57 @@
+# Pulse — SQLite Schema
+
+Storage layer for the MVP (see `docs/ARCHITECTURE.md` — "SQLite Over Postgres"). Backed by Node's built-in `node:sqlite` (`DatabaseSync`) — no native deps; migrations live in `src/db/migrations.sql` and run idempotently on `openDb()`.
+
+## Tables
+
+### `events`
+| Column | Type | Notes |
+|---|---|---|
+| `id` | INTEGER PK AUTOINCREMENT | |
+| `google_id` | TEXT UNIQUE NOT NULL | idempotency key from Google Calendar |
+| `title` | TEXT NOT NULL | |
+| `start_time` | TEXT NOT NULL | ISO 8601 |
+| `end_time` | TEXT | nullable |
+| `location` | TEXT | nullable |
+| `created_at` | TEXT NOT NULL | default `datetime('now')` |
+
+### `emails`
+| Column | Type | Notes |
+|---|---|---|
+| `id` | INTEGER PK AUTOINCREMENT | |
+| `gmail_id` | TEXT UNIQUE NOT NULL | idempotency key from Gmail |
+| `sender` | TEXT | |
+| `subject` | TEXT | |
+| `snippet` | TEXT | first ~200 chars |
+| `received_at` | TEXT NOT NULL | ISO 8601 |
+| `is_flagged` | INTEGER NOT NULL | 0/1 — set by keyword pass + Ollama scoring |
+| `scored_at` | TEXT | when Ollama scored it |
+
+### `briefings`
+| Column | Type | Notes |
+|---|---|---|
+| `id` | INTEGER PK AUTOINCREMENT | |
+| `generated_at` | TEXT NOT NULL | when the briefing was generated |
+| `content_raw` | TEXT | plain-text briefing |
+| `content_html` | TEXT | optional rendered HTML |
+
+### `nudges`
+| Column | Type | Notes |
+|---|---|---|
+| `id` | INTEGER PK AUTOINCREMENT | |
+| `event_id` | INTEGER | FK → `events.id` |
+| `nudge_type` | TEXT NOT NULL | e.g. `2h`, `30m` |
+| `sent_at` | TEXT NOT NULL | ISO 8601 |
+
+### `settings`
+| Column | Type | Notes |
+|---|---|---|
+| `key` | TEXT PK | |
+| `value` | TEXT | upsert semantics |
+
+## Notes
+
+- All timestamps stored as ISO 8601 TEXT (SQLite has no native datetime type).
+- `journal_mode = WAL` set on open for safe concurrent reads.
+- `data/` is gitignored — the DB file is created on first run.
+- Override the DB path with `PULSE_DB_PATH` (used by tests).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "test": "node --test"
+    "test": "node --experimental-sqlite --test"
   },
   "dependencies": {
     "express": "^4.21.2"

--- a/src/db/index.js
+++ b/src/db/index.js
@@ -1,0 +1,20 @@
+import { DatabaseSync } from "node:sqlite";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS = fs.readFileSync(path.join(__dirname, "migrations.sql"), "utf8");
+
+export function openDb(
+  dbPath = process.env.PULSE_DB_PATH || path.join(__dirname, "..", "..", "data", "pulse.sqlite")
+) {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  db.exec(MIGRATIONS);
+  return db;
+}
+
+export { MIGRATIONS };

--- a/src/db/migrations.sql
+++ b/src/db/migrations.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  google_id TEXT UNIQUE NOT NULL,
+  title TEXT NOT NULL,
+  start_time TEXT NOT NULL,
+  end_time TEXT,
+  location TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS emails (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  gmail_id TEXT UNIQUE NOT NULL,
+  sender TEXT,
+  subject TEXT,
+  snippet TEXT,
+  received_at TEXT NOT NULL,
+  is_flagged INTEGER NOT NULL DEFAULT 0,
+  scored_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS briefings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  generated_at TEXT NOT NULL,
+  content_raw TEXT,
+  content_html TEXT
+);
+
+CREATE TABLE IF NOT EXISTS nudges (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id INTEGER,
+  nudge_type TEXT NOT NULL,
+  sent_at TEXT NOT NULL,
+  FOREIGN KEY (event_id) REFERENCES events(id)
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { openDb } from "../src/db/index.js";
+
+function tmpDb() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulse-"));
+  return openDb(path.join(dir, "test.sqlite"));
+}
+
+test("openDb creates all 5 tables", () => {
+  const db = tmpDb();
+  const tables = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+    .all()
+    .map((r) => r.name);
+  for (const t of ["events", "emails", "briefings", "nudges", "settings"]) {
+    assert.ok(tables.includes(t), `missing table: ${t}`);
+  }
+  db.close();
+});
+
+test("migrations are idempotent (re-opening recreates dropped tables)", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulse-"));
+  const p = path.join(dir, "test.sqlite");
+  const db = openDb(p);
+  db.exec("DROP TABLE settings");
+  db.close();
+  const db2 = openDb(p);
+  const row = db2.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='settings'").get();
+  assert.ok(row, "settings table not recreated");
+  db2.close();
+});
+
+test("settings upsert works", () => {
+  const db = tmpDb();
+  const upsert = db.prepare(
+    "INSERT INTO settings(key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+  );
+  upsert.run("k1", "v1");
+  upsert.run("k1", "v2");
+  const v = db.prepare("SELECT value FROM settings WHERE key = 'k1'").get();
+  assert.equal(v.value, "v2");
+  db.close();
+});
+
+test("events unique on google_id prevents duplicates", () => {
+  const db = tmpDb();
+  const ins = db.prepare("INSERT INTO events(google_id, title, start_time) VALUES (?, ?, ?)");
+  ins.run("g1", "Dentist", "2026-07-21T15:00:00");
+  assert.throws(() => ins.run("g1", "Dup", "2026-07-21T15:00:00"));
+  const count = db.prepare("SELECT COUNT(*) AS n FROM events").get().n;
+  assert.equal(count, 1);
+  db.close();
+});


### PR DESCRIPTION
Closes #32

## What
- `src/db/index.js` — `openDb(path?)` using Node's built-in `node:sqlite` (`DatabaseSync`); creates `data/`, sets `journal_mode=WAL` + `foreign_keys=ON`, runs migrations, returns the db. `PULSE_DB_PATH` env override (for tests).
- `src/db/migrations.sql` — `events`, `emails`, `briefings`, `nudges`, `settings` (idempotent `CREATE TABLE IF NOT EXISTS`).
- `docs/SCHEMA.md` — table definitions with column types + intent (required by CORE-002 per ARCHITECTURE.md).
- `tests/db.test.js` — 4 tests: all 5 tables created; migrations idempotent (dropped table recreated on re-open); settings upsert; `events.google_id` UNIQUE prevents duplicates.
- `.env.example` — added `PULSE_DB_PATH` (optional).

## Why
Briefing engine, nudge engine, connectors, and API all need persistent storage. This is the storage layer they build on (epic CORE-002).

## Design note (finding)
Originally specced `better-sqlite3`, but it has **no prebuilt binary for node 26** and the native compile failed (node-gyp). Switched to Node's **built-in `node:sqlite`** — zero native deps, ships with node 26, same synchronous prepare/run/get/all ergonomics. No behavior change vs the issue's acceptance criteria.

## Verify
- `npm test` → 6 pass / 0 fail (4 new DB tests + existing 2 health).
- `data/` gitignored; DB created on first open.
- `docs/SCHEMA.md` matches migrations.

## Risk
Low. No secrets. No network. Pure local storage. No new external deps.
