### PR TITLE
Ollama client module (chatCompletion with safe fallback)

### DIFF
--- a/src/ollama/client.js
+++ b/src/ollama/client.js
@@ -1,0 +1,53 @@
+const DEFAULT_BASE = "http://localhost:11434";
+const DEFAULT_MODEL = "gemma4:e4b";
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/**
+ * Call the local Ollama (OpenAI-compatible) chat completions endpoint.
+ * Never throws — returns { ok: true, text } on success, { ok: false, error } on any failure.
+ * Callers (briefing engine, email scoring) must handle the { ok: false } path
+ * with a structured fallback so the user never sees a blank briefing card.
+ */
+export async function chatCompletion({ system, user, model, timeoutMs } = {}) {
+  const base = process.env.OLLAMA_BASE_URL || DEFAULT_BASE;
+  const mdl = model || process.env.OLLAMA_MODEL || DEFAULT_MODEL;
+  const timeout = timeoutMs || DEFAULT_TIMEOUT_MS;
+  const url = `${base}/v1/chat/completions`;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: mdl,
+        messages: [
+          { role: "system", content: system ?? "" },
+          { role: "user", content: user ?? "" },
+        ],
+        stream: false,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      return { ok: false, error: `HTTP ${res.status}` };
+    }
+
+    const data = await res.json();
+    const text = data?.choices?.[0]?.message?.content;
+    if (typeof text !== "string") {
+      return { ok: false, error: "no content in response" };
+    }
+    return { ok: true, text };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err?.name === "AbortError" ? `timeout after ${timeout}ms` : String(err?.message ?? err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/tests/ollama.test.js
+++ b/tests/ollama.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chatCompletion } from "../src/ollama/client.js";
+
+const originalFetch = globalThis.fetch;
+
+function withFetch(stub, fn) {
+  return async () => {
+    globalThis.fetch = stub;
+    try {
+      await fn();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  };
+}
+
+test("chatCompletion returns { ok: true, text } on 200", withFetch(
+  async (url, opts) => {
+    assert.equal(opts.method, "POST");
+    assert.ok(String(url).endsWith("/v1/chat/completions"));
+    const sent = JSON.parse(opts.body);
+    assert.equal(sent.stream, false);
+    assert.equal(sent.messages[0].role, "system");
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ choices: [{ message: { content: "briefing text" } }] }),
+    };
+  },
+  async () => {
+    const r = await chatCompletion({ system: "s", user: "u" });
+    assert.equal(r.ok, true);
+    assert.equal(r.text, "briefing text");
+  }
+));
+
+test("chatCompletion returns { ok: false } on connection refused (fetch throws)", withFetch(
+  async () => { throw new Error("ECONNREFUSED"); },
+  async () => {
+    const r = await chatCompletion({ system: "s", user: "u", timeoutMs: 50 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /ECONNREFUSED/);
+  }
+));
+
+test("chatCompletion returns { ok: false } on non-200", withFetch(
+  async () => ({ ok: false, status: 500, json: async () => ({}) }),
+  async () => {
+    const r = await chatCompletion({ system: "s", user: "u" });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /500/);
+  }
+));
+
+test("chatCompletion returns { ok: false } when content missing", withFetch(
+  async () => ({ ok: true, status: 200, json: async () => ({ choices: [] }) }),
+  async () => {
+    const r = await chatCompletion({ system: "s", user: "u" });
+    assert.equal(r.ok, false);
+  }
+));
+
+test("chatCompletion returns { ok: false } on timeout (abort)", async () => {
+  globalThis.fetch = (url, opts) =>
+    new Promise((_, reject) => {
+      opts.signal.addEventListener("abort", () =>
+        reject(new DOMException("aborted", "AbortError"))
+      );
+    });
+  try {
+    const r = await chatCompletion({ system: "s", user: "u", timeoutMs: 30 });
+    assert.equal(r.ok, false);
+    assert.match(r.error, /timeout/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
Closes #33

## What
- `src/ollama/client.js` — `chatCompletion({ system, user, model?, timeoutMs? })` → `{ ok: true, text } | { ok: false, error }`. POSTs to `${OLLAMA_BASE_URL}/v1/chat/completions` (OpenAI-compatible), `stream:false`, `AbortController` timeout. **Never throws** — any failure (connection refused, non-200, missing content, timeout) returns `{ ok:false, error }` so callers can fall back to a structured summary instead of crashing.
- `tests/ollama.test.js` — 5 tests with a **mocked fetch** (no real Ollama dependency): ok-text on 200; ok:false on connection-refused; ok:false on non-200; ok:false on missing content; ok:false on timeout (abort).

## Why
Briefing engine + email-scoring both need a local LLM call (ARCHITECTURE.md). This is the safe client they consume — the `{ok:false}` contract is what guarantees the user never sees a blank briefing card (engines fall back to structured text on failure).

## Verify
- `npm test` → 11 pass / 0 fail (5 new ollama + 4 db + 2 health).
- No real Ollama required — all fetch paths mocked.

## Risk
Low. No secrets. No network in tests. No new deps (uses global `fetch` + `AbortController`, both built into node 22+).
