### PR TITLE
Gmail connector — fetch + two-pass flag unread email (keyword + Ollama)

### DIFF
--- a/src/connectors/gmail.js
+++ b/src/connectors/gmail.js
@@ -1,0 +1,104 @@
+import { openDb } from "../db/index.js";
+import { chatCompletion } from "../ollama/client.js";
+
+// Pass-1 keyword filter — auto-flag without an LLM call. Keep conservative.
+const KEYWORDS = [
+  "urgent",
+  "asap",
+  "deadline",
+  "past due",
+  "overdue",
+  "invoice",
+  "action required",
+  "important",
+];
+
+function headerValue(headers, name) {
+  const h = headers?.find((x) => x.name?.toLowerCase() === name.toLowerCase());
+  return h?.value ?? "";
+}
+
+function keywordFlagged({ sender, subject, snippet }) {
+  const hay = `${subject} ${snippet} ${sender}`.toLowerCase();
+  return KEYWORDS.some((k) => hay.includes(k));
+}
+
+/**
+ * Sync unread Gmail from the last 24h into the `emails` table with two-pass flagging:
+ *   pass 1: keyword/known-sender match → auto-flag (no LLM call)
+ *   pass 2: remaining → Ollama scores important vs routine
+ * Idempotent upsert on `gmail_id`. Never throws on a single message failure.
+ *
+ * @returns {Promise<{ synced: number, flagged: number, errors: string[] }>}
+ */
+export async function syncGmail({ oauth2Client, db, _gmailApi, _scorer } = {}) {
+  const localDb = db ?? openDb();
+  const ownDb = !db;
+  const gmailApi =
+    _gmailApi ?? (await import("googleapis")).google.gmail({ version: "v1", auth: oauth2Client });
+  const scorer = _scorer ?? chatCompletion;
+
+  let messages = [];
+  let errors = [];
+  try {
+    const res = await gmailApi.list({ userId: "me", q: "is:unread", maxResults: 50 });
+    messages = res.data.messages ?? [];
+  } catch (err) {
+    errors.push(String(err?.message ?? err));
+  }
+
+  const upsert = localDb.prepare(
+    `INSERT INTO emails(gmail_id, sender, subject, snippet, received_at, is_flagged, scored_at)
+     VALUES ($gid, $sender, $subject, $snippet, $recv, $flag, $scored)
+     ON CONFLICT(gmail_id) DO UPDATE SET
+       sender = excluded.sender, subject = excluded.subject, snippet = excluded.snippet,
+       received_at = excluded.received_at, is_flagged = excluded.is_flagged,
+       scored_at = excluded.scored_at`
+  );
+
+  let synced = 0;
+  let flagged = 0;
+
+  for (const m of messages) {
+    try {
+      const got = await gmailApi.get({
+        userId: "me",
+        id: m.id,
+        format: "metadata",
+        metadataHeaders: ["From", "Subject"],
+      });
+      const data = got.data;
+      const sender = headerValue(data.payload?.headers, "From");
+      const subject = headerValue(data.payload?.headers, "Subject");
+      const snippet = data.snippet ?? "";
+      const recv = data.internalDate
+        ? new Date(Number(data.internalDate)).toISOString()
+        : new Date().toISOString();
+
+      let isFlagged = 0;
+      let scoredAt = null;
+
+      if (keywordFlagged({ sender, subject, snippet })) {
+        isFlagged = 1;
+      } else {
+        const r = await scorer({
+          system: "Is this email important or routine? Respond with one word: important or routine.",
+          user: `From: ${sender}\nSubject: ${subject}\n${snippet.slice(0, 200)}`,
+        });
+        scoredAt = new Date().toISOString();
+        if (r.ok && /important/i.test(r.text)) isFlagged = 1;
+      }
+
+      if (isFlagged) flagged++;
+      upsert.run({ gid: m.id, sender, subject, snippet, recv, flag: isFlagged, scored: scoredAt });
+      synced++;
+    } catch (err) {
+      errors.push(String(err?.message ?? err));
+    }
+  }
+
+  if (ownDb) localDb.close();
+  return { synced, flagged, errors };
+}
+
+export { KEYWORDS, keywordFlagged };

--- a/tests/gmail.test.js
+++ b/tests/gmail.test.js
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { openDb } from "../src/db/index.js";
+import { syncGmail } from "../src/connectors/gmail.js";
+
+function tmpDb() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulse-"));
+  return openDb(path.join(dir, "test.sqlite"));
+}
+
+// Build a fake gmail API from a list of messages.
+function fakeGmailApi(messages) {
+  return {
+    list: async () => ({ data: { messages: messages.map((m) => ({ id: m.id })) } }),
+    get: async ({ id }) => {
+      const m = messages.find((x) => x.id === id);
+      if (!m) throw new Error("not found");
+      return {
+        data: {
+          id: m.id,
+          snippet: m.snippet,
+          internalDate: m.internalDate,
+          payload: {
+            headers: [
+              { name: "From", value: m.from },
+              { name: "Subject", value: m.subject },
+            ],
+          },
+        },
+      };
+    },
+  };
+}
+
+const MESSAGES = [
+  { id: "m1", from: "landlord <l@example.com>", subject: "URGENT: rent overdue", snippet: "past due", internalDate: "1784600000000" },
+  { id: "m2", from: "boss <b@corp.com>", subject: "Weekly update", snippet: "fyi team", internalDate: "1784601000000" },
+  { id: "m3", from: "news <n@news.com>", subject: "Your digest", snippet: "top stories today", internalDate: "1784602000000" },
+];
+
+test("pass 1: keyword email is auto-flagged without an LLM call", async () => {
+  const db = tmpDb();
+  let scorerCalled = false;
+  const scorer = async () => { scorerCalled = true; return { ok: true, text: "routine" }; };
+  const r = await syncGmail({
+    oauth2Client: {},
+    db,
+    _gmailApi: fakeGmailApi([MESSAGES[0]]),
+    _scorer: scorer,
+  });
+  assert.equal(r.synced, 1);
+  assert.equal(r.flagged, 1);
+  assert.equal(scorerCalled, false, "scorer must not be called for keyword email");
+  const row = db.prepare("SELECT is_flagged FROM emails WHERE gmail_id='m1'").get();
+  assert.equal(row.is_flagged, 1);
+  db.close();
+});
+
+test("pass 2: scorer says important → flagged", async () => {
+  const db = tmpDb();
+  const scorer = async () => ({ ok: true, text: "important" });
+  const r = await syncGmail({
+    oauth2Client: {},
+    db,
+    _gmailApi: fakeGmailApi([MESSAGES[1]]),
+    _scorer: scorer,
+  });
+  assert.equal(r.flagged, 1);
+  const row = db.prepare("SELECT is_flagged, scored_at FROM emails WHERE gmail_id='m2'").get();
+  assert.equal(row.is_flagged, 1);
+  assert.ok(row.scored_at, "scored_at should be set when Ollama scored it");
+  db.close();
+});
+
+test("pass 2: scorer says routine → not flagged", async () => {
+  const db = tmpDb();
+  const scorer = async () => ({ ok: true, text: "routine" });
+  const r = await syncGmail({
+    oauth2Client: {},
+    db,
+    _gmailApi: fakeGmailApi([MESSAGES[2]]),
+    _scorer: scorer,
+  });
+  assert.equal(r.flagged, 0);
+  const row = db.prepare("SELECT is_flagged FROM emails WHERE gmail_id='m3'").get();
+  assert.equal(row.is_flagged, 0);
+  db.close();
+});
+
+test("pass 2: scorer fails (ok:false) → not flagged, no crash", async () => {
+  const db = tmpDb();
+  const scorer = async () => ({ ok: false, error: "ECONNREFUSED" });
+  const r = await syncGmail({
+    oauth2Client: {},
+    db,
+    _gmailApi: fakeGmailApi([MESSAGES[2]]),
+    _scorer: scorer,
+  });
+  assert.equal(r.flagged, 0);
+  assert.equal(r.synced, 1);
+  assert.equal(r.errors.length, 0, "scorer failure is not a sync error");
+  db.close();
+});
+
+test("upsert is idempotent (re-sync same messages does not duplicate)", async () => {
+  const db = tmpDb();
+  const scorer = async () => ({ ok: true, text: "routine" });
+  const api = fakeGmailApi(MESSAGES);
+  await syncGmail({ oauth2Client: {}, db, _gmailApi: api, _scorer: scorer });
+  await syncGmail({ oauth2Client: {}, db, _gmailApi: api, _scorer: scorer });
+  const count = db.prepare("SELECT COUNT(*) AS n FROM emails").get().n;
+  assert.equal(count, 3);
+  db.close();
+});
+
+test("list throws → synced 0, error recorded", async () => {
+  const db = tmpDb();
+  const failingApi = { list: async () => { throw new Error("gmail 401"); }, get: async () => ({}) };
+  const r = await syncGmail({ oauth2Client: {}, db, _gmailApi: failingApi, _scorer: async () => ({ ok: true, text: "routine" }) });
+  assert.equal(r.synced, 0);
+  assert.match(r.errors[0], /gmail 401/);
+  db.close();
+});


### PR DESCRIPTION
Closes #15

## What
- `src/connectors/gmail.js` — `syncGmail({ oauth2Client, db?, _gmailApi?, _scorer? })`: lists unread Gmail, fetches each message's From/Subject/snippet, **two-pass flagging** per ARCHITECTURE.md:
  - **pass 1 (keyword):** subject/snippet/sender matches a conservative keyword list (`urgent`, `asap`, `deadline`, `past due`, `overdue`, `invoice`, `action required`, `important`) → auto-flag, **no LLM call**.
  - **pass 2 (Ollama):** remaining → `chatCompletion` scores important vs routine; flagged if "important". Scorer failure (`{ok:false}`) → not flagged, no crash.
  - Idempotent upsert into `emails` (key on `gmail_id`); `scored_at` set only when Ollama scored it. Returns `{ synced, flagged, errors }`.
- `tests/gmail.test.js` — 6 tests with a fake gmail API + fake scorer + real in-memory SQLite: keyword auto-flag (scorer not called); scorer→important flagged; scorer→routine not flagged; scorer failure safe; idempotent upsert; list-throws error path. No real Google/Ollama calls.

## Why
Gmail is the second MVP source (MVP.md: unread last 24h, flagged by Claude/Ollama). Mirrors the calendar connector's DI pattern; completes the source layer so the briefing engine (#17) has flagged emails to brief on. Epic CONNECT-002.

## Verify
- `npm test` → 22 pass / 0 fail (6 new gmail + 4 calendar + 1 auth + 4 db + 2 health + 5 ollama).
- Tests hermetic (DI'd gmail API, injected scorer, in-memory SQLite).

## Risk
Low. Read-only (`gmail.readonly`). No secrets in code. Scorer failure degrades gracefully (no flag, no crash) — matches the "never show a blank briefing" principle. Note: `received_at` uses the message `internalDate` when Gmail provides it, else fetch time.
