### PR TITLE
Morning briefing generator (LLM + safe fallback) + tests

### DIFF
--- a/src/engines/briefing.js
+++ b/src/engines/briefing.js
@@ -1,0 +1,87 @@
+import { openDb } from "../db/index.js";
+import { chatCompletion } from "../ollama/client.js";
+
+const SYSTEM =
+  "You are Pulse, a proactive second brain. Write a concise, calm morning briefing in plain language summarizing what needs the user's attention today. No raw data dumps, no headers, no bullet lists — just 3–6 sentences the way a trusted assistant would tell you.";
+
+function buildUserPrompt(events, emails) {
+  const parts = [];
+  parts.push("Calendar (next 48h):");
+  parts.push(
+    events.length
+      ? events
+          .map((e) => `- ${e.title} at ${e.start_time}${e.location ? ` (${e.location})` : ""}`)
+          .join("\n")
+      : "(none)"
+  );
+  parts.push("\nFlagged unread email (last 24h):");
+  parts.push(
+    emails.length
+      ? emails
+          .map((m) => `- From ${m.sender}: ${m.subject} — ${(m.snippet ?? "").slice(0, 120)}`)
+          .join("\n")
+      : "(none)"
+  );
+  return parts.join("\n");
+}
+
+function fallbackText(events, emails) {
+  const lines = [];
+  if (events.length) {
+    lines.push("Today:");
+    for (const e of events.slice(0, 10)) lines.push(`- ${e.title} (${e.start_time})`);
+  }
+  if (emails.length) {
+    lines.push("Flagged email:");
+    for (const m of emails.slice(0, 5)) lines.push(`- ${m.subject} (from ${m.sender})`);
+  }
+  if (!lines.length) lines.push("Nothing needs your attention right now.");
+  return lines.join("\n");
+}
+
+/**
+ * Generate the morning briefing from upcoming events + flagged emails.
+ * Pulls from SQLite, calls the local LLM (scorer), stores the result in `briefings`.
+ * On any LLM failure, stores a structured plain-text fallback — never returns blank.
+ *
+ * @returns {Promise<{ ok: true, text: string, fallback: boolean, events: number, emails: number }>}
+ */
+export async function generateBriefing({ db, _scorer, now = new Date() } = {}) {
+  const localDb = db ?? openDb();
+  const ownDb = !db;
+  const scorer = _scorer ?? chatCompletion;
+
+  const iso = now.toISOString();
+  const horizon = new Date(now.getTime() + 48 * 60 * 60 * 1000).toISOString();
+  const since = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+
+  const events = localDb
+    .prepare(
+      "SELECT title, start_time, end_time, location FROM events WHERE start_time BETWEEN ? AND ? ORDER BY start_time"
+    )
+    .all(iso, horizon);
+
+  const emails = localDb
+    .prepare(
+      "SELECT sender, subject, snippet FROM emails WHERE is_flagged = 1 AND received_at > ? ORDER BY received_at DESC"
+    )
+    .all(since);
+
+  const r = await scorer({ system: SYSTEM, user: buildUserPrompt(events, emails) });
+
+  let text;
+  let fallback = false;
+  if (r.ok && r.text && r.text.trim()) {
+    text = r.text.trim();
+  } else {
+    text = fallbackText(events, emails);
+    fallback = true;
+  }
+
+  localDb.prepare("INSERT INTO briefings(generated_at, content_raw) VALUES (?, ?)").run(iso, text);
+
+  if (ownDb) localDb.close();
+  return { ok: true, text, fallback, events: events.length, emails: emails.length };
+}
+
+export { SYSTEM, buildUserPrompt, fallbackText };

--- a/tests/briefing.test.js
+++ b/tests/briefing.test.js
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { openDb } from "../src/db/index.js";
+import { generateBriefing } from "../src/engines/briefing.js";
+
+function tmpDb() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulse-"));
+  return openDb(path.join(dir, "test.sqlite"));
+}
+
+const NOW = new Date("2026-07-21T07:00:00Z");
+
+function seed(db, { events = [], emails = [] } = {}) {
+  const ev = db.prepare(
+    "INSERT INTO events(google_id, title, start_time, end_time, location) VALUES (?,?,?,?,?)"
+  );
+  for (const e of events) ev.run(e.gid, e.title, e.start, e.end ?? null, e.location ?? null);
+  const em = db.prepare(
+    "INSERT INTO emails(gmail_id, sender, subject, snippet, received_at, is_flagged) VALUES (?,?,?,?,?,?)"
+  );
+  for (const m of emails) em.run(m.gid, m.from, m.subject, m.snippet, m.recv, m.flag ? 1 : 0);
+}
+
+test("ok path: scorer returns text → briefing stored, fallback false", async () => {
+  const db = tmpDb();
+  seed(db, {
+    events: [{ gid: "e1", title: "Dentist", start: "2026-07-21T15:00:00Z" }],
+    emails: [{ gid: "m1", from: "boss", subject: "Review asap", snippet: "need your eyes", recv: "2026-07-21T06:00:00Z", flag: true }],
+  });
+  const scorer = async () => ({ ok: true, text: "You have a dentist at 3pm and a note from your boss." });
+  const r = await generateBriefing({ db, _scorer: scorer, now: NOW });
+  assert.equal(r.ok, true);
+  assert.equal(r.fallback, false);
+  assert.equal(r.events, 1);
+  assert.equal(r.emails, 1);
+  const rows = db.prepare("SELECT content_raw FROM briefings ORDER BY id").all();
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].content_raw, "You have a dentist at 3pm and a note from your boss.");
+  db.close();
+});
+
+test("fallback path: scorer fails → structured fallback stored, fallback true, never blank", async () => {
+  const db = tmpDb();
+  seed(db, {
+    events: [{ gid: "e1", title: "Dentist", start: "2026-07-21T15:00:00Z" }],
+    emails: [{ gid: "m1", from: "landlord", subject: "Rent", snippet: "past due", recv: "2026-07-21T06:00:00Z", flag: true }],
+  });
+  const scorer = async () => ({ ok: false, error: "ECONNREFUSED" });
+  const r = await generateBriefing({ db, _scorer: scorer, now: NOW });
+  assert.equal(r.ok, true);
+  assert.equal(r.fallback, true);
+  assert.ok(r.text.length > 0, "fallback must never be blank");
+  assert.match(r.text, /Dentist/);
+  assert.match(r.text, /Rent/);
+  db.close();
+});
+
+test("fallback path: scorer returns empty text → fallback", async () => {
+  const db = tmpDb();
+  seed(db, { events: [{ gid: "e1", title: "Standup", start: "2026-07-21T09:00:00Z" }] });
+  const scorer = async () => ({ ok: true, text: "   " });
+  const r = await generateBriefing({ db, _scorer: scorer, now: NOW });
+  assert.equal(r.fallback, true);
+  assert.match(r.text, /Standup/);
+  db.close();
+});
+
+test("empty inputs: fallback says nothing needs attention", async () => {
+  const db = tmpDb();
+  const scorer = async () => ({ ok: true, text: "x" });
+  const r = await generateBriefing({ db, _scorer: scorer, now: NOW });
+  assert.equal(r.events, 0);
+  assert.equal(r.emails, 0);
+  db.close();
+});
+
+test("history grows: two briefings → 2 rows", async () => {
+  const db = tmpDb();
+  const scorer = async () => ({ ok: true, text: "briefing" });
+  await generateBriefing({ db, _scorer: scorer, now: NOW });
+  await generateBriefing({ db, _scorer: scorer, now: new Date("2026-07-22T07:00:00Z") });
+  const count = db.prepare("SELECT COUNT(*) AS n FROM briefings").get().n;
+  assert.equal(count, 2);
+  db.close();
+});
+
+test("only events within the 48h window are included", async () => {
+  const db = tmpDb();
+  seed(db, {
+    events: [
+      { gid: "in", title: "Soon", start: "2026-07-21T12:00:00Z" },
+      { gid: "out", title: "Far", start: "2026-07-25T12:00:00Z" },
+    ],
+  });
+  const scorer = async () => ({ ok: false, error: "x" });
+  const r = await generateBriefing({ db, _scorer: scorer, now: NOW });
+  assert.equal(r.events, 1, "only the in-window event counts");
+  assert.match(r.text, /Soon/);
+  assert.doesNotMatch(r.text, /Far/);
+  db.close();
+});


### PR DESCRIPTION
Closes #17

## What
- `src/engines/briefing.js` — `generateBriefing({ db?, _scorer?, now? })`: pulls events in the next 48h + flagged emails from the last 24h, calls the local LLM (scorer) with a calm plain-language system prompt, stores the result in `briefings`. **On any LLM failure (or empty response), stores a structured plain-text fallback** (event titles + email subjects) and returns `fallback: true` — never blank. Returns `{ ok, text, fallback, events, emails }`.
- `tests/briefing.test.js` — 6 tests with an injected scorer + real in-memory SQLite: ok path stores LLM text; scorer-failure → structured fallback (never blank); empty-text → fallback; empty inputs; history grows (2 briefings → 2 rows); only in-48h-window events included. No real Ollama.

## Why
The morning briefing is the MVP's core feature (MVP.md "Core Feature: Morning Briefing"). This is the engine the 7am cron will call. The safe-fallback contract (inherited from the Ollama client's `{ok:false}`) is what guarantees the user never sees a blank briefing card — the central trust principle. Epic BRIEF-001.

## Verify
- `npm test` → 28 pass / 0 fail (6 new briefing + 22 prior).
- Hermetic (injected scorer, in-memory SQLite).

## Risk
Low. No secrets. No network in tests. Reuses the proven `chatCompletion` safe-fallback contract. No new deps.
