### PR TITLE
Dashboard live feed + briefing + status (closes #22)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,6 +2,8 @@
 
 All work tracked here. Issues are grouped by epic. Status moves from Open → In Progress → Completed.
 
+Each issue is written to be executable by Cursor. Exact file paths, exact commands, exact acceptance criteria. No assumptions.
+
 ---
 
 ## Epics
@@ -10,487 +12,941 @@ All work tracked here. Issues are grouped by epic. Status moves from Open → In
 |---|---|---|
 | CORE | Core Infrastructure | Server, auth, storage, config |
 | CONNECT | Data Source Connectors | Google Calendar and Gmail integration |
-| BRIEF | Morning Briefing Engine | AI-powered daily briefing generation and delivery |
+| BRIEF | Morning Briefing Engine | Ollama-powered daily briefing generation and delivery |
 | NUDGE | Proactive Nudge System | Event reminders and scheduled push alerts |
 | UI | Dashboard UI | Web interface — feed, panels, status bar |
-| BIZ | Business Version | Team brain, per-employee sub-brains (future) |
 | INFRA | DevOps & Packaging | Deploy, scripts, health checks, docs |
 
 ---
 
-## Issues
-
----
+## CORE Epic
 
 ### [CORE-001] Initialize Express server with base routing
-**Epic:** CORE  
 **Priority:** Critical  
 **Effort:** S  
 **Status:** Open  
 
-Set up the Node.js + Express server as the backbone of Pulse. This is the foundation everything else runs on.
+Set up the Node.js + Express server as the foundation. This is blocking all other work.
 
-Acceptance criteria:
-- [ ] `npm start` starts the server on port 3000
-- [ ] GET `/` returns the dashboard HTML
-- [ ] GET `/health` returns `{ status: "ok", timestamp: ... }`
-- [ ] Server restarts automatically on crash (use `nodemon` for dev, `pm2` for prod)
-- [ ] `.env` file loaded via `dotenv` for all secrets and config
+**Acceptance criteria:**
+- [ ] File `package.json` exists at project root with `"main": "server.js"` and scripts: `{ "start": "node server.js", "dev": "nodemon server.js" }`
+- [ ] Dependencies installed: `express@4.18.2`, `dotenv@16.0.3`, `node-cron@3.0.2`, `nodemon@2.0.22` (dev only)
+- [ ] File `server.js` exists at project root
+- [ ] `npm start` starts Express on port 3000 (from `process.env.PORT || 3000`)
+- [ ] GET `/` returns the file at `public/index.html` with content-type `text/html`
+- [ ] GET `/health` returns JSON: `{ status: "ok", timestamp: new Date().toISOString(), uptime: process.uptime() }`
+- [ ] GET `/login` returns the file at `public/login.html`
+- [ ] `.env` file is loaded via `require('dotenv').config()` at server.js top
+- [ ] GET to a non-existent route returns HTTP 404 with JSON: `{ error: "Not Found" }`
+- [ ] Server includes `const cron = require('node-cron')` at top (placeholder for future cron jobs)
+- [ ] Listening on port 3000 with console log: `Pulse server running on http://localhost:${PORT}`
+
+**Implementation notes:**
+```javascript
+// server.js structure
+const express = require('express');
+const path = require('path');
+require('dotenv').config();
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static('public'));
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+app.get('/health', (req, res) => {
+  res.json({
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime()
+  });
+});
+
+app.get('/login', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'login.html'));
+});
+
+app.use((req, res) => {
+  res.status(404).json({ error: 'Not Found' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Pulse server running on http://localhost:${PORT}`);
+});
+```
+
+**Test command:**
+```bash
+npm start
+# Then: curl http://localhost:3000/health
+# Expected: {"status":"ok","timestamp":"...","uptime":...}
+```
 
 ---
 
 ### [CORE-002] SQLite schema — events, emails, briefings, nudges, settings
-**Epic:** CORE  
 **Priority:** Critical  
 **Effort:** M  
 **Status:** Open  
 
-Design and initialize the full SQLite database schema. All Pulse data lives here.
+Initialize the SQLite database and create all tables. Data lives here.
 
-Tables needed:
-- `events` — id, title, start_time, end_time, location, source, synced_at
-- `emails` — id, subject, sender, received_at, snippet, is_flagged, synced_at
-- `briefings` — id, generated_at, content_raw, content_html
-- `nudges` — id, event_id, nudge_type (2hr/30min), sent_at, skipped (bool)
-- `settings` — key, value (simple key-value store)
+**Acceptance criteria:**
+- [ ] Dependencies installed: `better-sqlite3@9.0.0`
+- [ ] Directory `db/` exists at project root
+- [ ] File `db/init.sql` exists with full DDL for 5 tables (see schema below)
+- [ ] File `db/database.js` exists, exports a single `Database` instance initialized at project root as `./pulse.db`
+- [ ] `db/database.js` calls `db.exec(fs.readFileSync('./db/init.sql', 'utf-8'))` on startup
+- [ ] All tables created with `CREATE TABLE IF NOT EXISTS` (idempotent)
+- [ ] `settings` table seeded with defaults on first run: `INSERT OR IGNORE INTO settings (key, value) VALUES ('nudges_per_day', '3'), ('briefing_time', '07:00'), ...`
+- [ ] File `docs/SCHEMA.md` documents each table: name, columns (type, constraints), purpose
+- [ ] Running `node -e "require('./db/database.js')"` initializes the DB with zero errors
+- [ ] File `./pulse.db` exists after initialization
+- [ ] Running init a second time (idempotent) does not error and leaves data intact
 
-Acceptance criteria:
-- [ ] Schema initialized via a `db/init.sql` file on server startup
-- [ ] `better-sqlite3` used as the SQLite driver
-- [ ] All tables created idempotently (no crash if already exists)
-- [ ] `settings` table seeded with defaults: `nudges_per_day=3`, `briefing_time=07:00`
-- [ ] Schema is documented with column types and descriptions in `docs/SCHEMA.md`
+**Schema (to be in db/init.sql):**
+```sql
+CREATE TABLE IF NOT EXISTS events (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  start_time INTEGER NOT NULL,  -- Unix timestamp
+  end_time INTEGER NOT NULL,
+  location TEXT,
+  calendar_id TEXT,
+  synced_at INTEGER DEFAULT (unixepoch())
+);
+
+CREATE TABLE IF NOT EXISTS emails (
+  id TEXT PRIMARY KEY,
+  subject TEXT NOT NULL,
+  sender TEXT NOT NULL,
+  received_at INTEGER NOT NULL,  -- Unix timestamp
+  snippet TEXT,
+  is_flagged INTEGER DEFAULT 0,
+  synced_at INTEGER DEFAULT (unixepoch())
+);
+
+CREATE TABLE IF NOT EXISTS briefings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  generated_at INTEGER NOT NULL,  -- Unix timestamp
+  content_raw TEXT NOT NULL,
+  content_html TEXT
+);
+
+CREATE TABLE IF NOT EXISTS nudges (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_id TEXT NOT NULL,
+  nudge_type TEXT NOT NULL,  -- "2hr" or "30min"
+  sent_at INTEGER NOT NULL,  -- Unix timestamp
+  skipped INTEGER DEFAULT 0,
+  UNIQUE(event_id, nudge_type)
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at INTEGER DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_start_time ON events(start_time);
+CREATE INDEX IF NOT EXISTS idx_emails_received_at ON emails(received_at);
+CREATE INDEX IF NOT EXISTS idx_emails_is_flagged ON emails(is_flagged);
+CREATE INDEX IF NOT EXISTS idx_briefings_generated_at ON briefings(generated_at);
+```
+
+**db/database.js structure:**
+```javascript
+const Database = require('better-sqlite3');
+const fs = require('fs');
+const path = require('path');
+
+const db = new Database('./pulse.db');
+db.pragma('journal_mode = WAL');
+
+const schema = fs.readFileSync(path.join(__dirname, 'init.sql'), 'utf-8');
+db.exec(schema);
+
+// Seed settings table (idempotent)
+db.exec(`
+  INSERT OR IGNORE INTO settings (key, value) VALUES 
+  ('nudges_per_day', '3'),
+  ('briefing_time', '07:00'),
+  ('last_calendar_sync', '0'),
+  ('last_gmail_sync', '0'),
+  ('last_dashboard_open', '0'),
+  ('nudges_sent_today', '0');
+`);
+
+module.exports = db;
+```
+
+**Test command:**
+```bash
+rm -f pulse.db  # Start fresh
+node -e "require('./db/database.js')"
+sqlite3 pulse.db "SELECT name FROM sqlite_master WHERE type='table';"
+# Expected: events, emails, briefings, nudges, settings
+```
 
 ---
 
-### [CORE-003] Single-user password protection
-**Epic:** CORE  
+### [CORE-003] Single-user password protection + session management
 **Priority:** Critical  
-**Effort:** S  
+**Effort:** M  
 **Status:** Open  
 
-Protect the dashboard with a simple password. Not multi-user auth — just a gate to keep the dashboard private on a shared network.
+Protect the dashboard with a password gate. No multi-user auth — just a simple wall.
 
-Acceptance criteria:
-- [ ] Password set in `.env` as `PULSE_PASSWORD`
-- [ ] Unauthenticated requests to any route redirect to `/login`
-- [ ] Session cookie issued on successful login (expires after 7 days)
-- [ ] Logout endpoint at GET `/logout`
-- [ ] Login page is minimal — just a password field and submit button
+**Acceptance criteria:**
+- [ ] Dependencies installed: `express-session@1.17.3`, `cookie-parser@1.4.6`
+- [ ] `.env` contains `SESSION_SECRET=<random-string>` (at least 32 chars, generated by `openssl rand -hex 16`)
+- [ ] `.env.example` includes `SESSION_SECRET` (no value)
+- [ ] `.env.example` includes `PULSE_PASSWORD` (no value)
+- [ ] File `src/routes/auth.js` exists and exports router
+- [ ] GET `/login` returns `public/login.html`
+- [ ] POST `/login` with JSON body `{ password: "..." }` checks password against `process.env.PULSE_PASSWORD`
+  - On success: set session cookie `res.session.authenticated = true`, return JSON `{ success: true, redirect: '/' }`
+  - On failure: return JSON `{ success: false, error: "Invalid password" }` with HTTP 401
+- [ ] GET `/logout` clears session and redirects to `/login`
+- [ ] Session cookie expires after 7 days (via `cookie: { maxAge: 7*24*60*60*1000 }`)
+- [ ] All routes except `/login`, `/health`, and `/logout` check `req.session.authenticated` — if false, redirect to `/login`
+- [ ] File `public/login.html` has a form with password field and submit button (no username)
+- [ ] Starting server without `PULSE_PASSWORD` env var fails with error message: `Error: PULSE_PASSWORD not set in .env`
+
+**Implementation in server.js:**
+```javascript
+const session = require('express-session');
+const cookieParser = require('cookie-parser');
+const authRouter = require('./src/routes/auth');
+
+app.use(cookieParser());
+app.use(session({
+  secret: process.env.SESSION_SECRET,
+  resave: false,
+  saveUninitialized: false,
+  cookie: { maxAge: 7*24*60*60*1000 }
+}));
+
+// Check if PULSE_PASSWORD is set
+if (!process.env.PULSE_PASSWORD) {
+  throw new Error('Error: PULSE_PASSWORD not set in .env');
+}
+
+app.use('/auth', authRouter);
+
+// Middleware to protect all routes except login/health
+app.use((req, res, next) => {
+  const publicRoutes = ['/login', '/health', '/auth/login'];
+  if (publicRoutes.includes(req.path)) {
+    return next();
+  }
+  if (!req.session.authenticated) {
+    return res.redirect('/login');
+  }
+  next();
+});
+```
+
+**Test command:**
+```bash
+PULSE_PASSWORD=testpass npm start
+# Then in another terminal:
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"password":"testpass"}' -c cookies.txt
+curl http://localhost:3000/ -b cookies.txt
+# Expected: returns dashboard HTML (not redirect)
+```
 
 ---
 
 ### [CORE-004] Config and secrets management
-**Epic:** CORE  
 **Priority:** Critical  
 **Effort:** XS  
 **Status:** Open  
 
-Establish the pattern for managing all secrets and config so nothing is ever committed to git.
+Establish the pattern for managing secrets so nothing is committed to git.
 
-Acceptance criteria:
-- [ ] `.env.example` checked into git with all required keys (no values)
-- [ ] `.env` added to `.gitignore`
-- [ ] Server fails fast with a clear error message if any required env var is missing
-- [ ] README includes setup instructions referencing `.env.example`
+**Acceptance criteria:**
+- [ ] File `.env.example` exists at project root with all required keys (no values)
+- [ ] `.env` is in `.gitignore`
+- [ ] `.gitignore` also includes: `node_modules/`, `pulse.db*`, `*.log`, `.DS_Store`
+- [ ] Server fails on startup with a clear error if any of these are missing from `.env`:
+  - `PULSE_PASSWORD`
+  - `GOOGLE_CLIENT_ID`
+  - `GOOGLE_CLIENT_SECRET`
+  - `SESSION_SECRET`
+  - `VAPID_EMAIL`
+  - `VAPID_PUBLIC_KEY`
+  - `VAPID_PRIVATE_KEY`
+- [ ] README includes section "Setup" with step: "Copy `.env.example` to `.env` and fill in all values"
+- [ ] Error message on missing var is clear: `Error: Missing required env var: PULSE_PASSWORD`
+
+**Contents of .env.example:**
+```
+# Server
+PORT=3000
+SESSION_SECRET=<generate-with: openssl-rand-hex-16>
+PULSE_PASSWORD=
+
+# Google OAuth
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:3000/oauth/callback
+
+# Ollama
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=gemma4:e4b
+
+# Briefing
+BRIEFING_TIME=07:00
+
+# Web Push
+VAPID_EMAIL=
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+
+# Twilio (optional)
+TWILIO_ENABLED=false
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_FROM_NUMBER=
+TWILIO_TO_NUMBER=
+```
+
+**Validation in server.js:**
+```javascript
+const requiredEnvVars = [
+  'PULSE_PASSWORD',
+  'GOOGLE_CLIENT_ID',
+  'GOOGLE_CLIENT_SECRET',
+  'SESSION_SECRET',
+  'VAPID_EMAIL',
+  'VAPID_PUBLIC_KEY',
+  'VAPID_PRIVATE_KEY'
+];
+
+for (const varName of requiredEnvVars) {
+  if (!process.env[varName]) {
+    throw new Error(`Error: Missing required env var: ${varName}`);
+  }
+}
+```
 
 ---
 
+## CONNECT Epic
+
 ### [CONNECT-001] Google OAuth 2.0 login flow
-**Epic:** CONNECT  
 **Priority:** Critical  
 **Effort:** M  
 **Status:** Open  
 
-Implement Google OAuth so Pulse can read Calendar and Gmail on behalf of the user. Read-only scopes only.
+Implement Google OAuth so Pulse can read Calendar and Gmail. Read-only scopes only.
 
-Acceptance criteria:
-- [ ] OAuth flow triggered from dashboard settings page
-- [ ] Scopes requested: `https://www.googleapis.com/auth/calendar.readonly` and `https://www.googleapis.com/auth/gmail.readonly`
-- [ ] Access token and refresh token stored in `settings` table (not in `.env`)
-- [ ] Token refresh handled automatically — never expires mid-session
-- [ ] Disconnect button revokes token and clears stored credentials
-- [ ] OAuth redirect URI works on localhost
+**Acceptance criteria:**
+- [ ] Dependencies installed: `googleapis@118.0.0`
+- [ ] `.env` contains `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI=http://localhost:3000/oauth/callback`
+- [ ] File `src/routes/oauth.js` exists and exports router
+- [ ] GET `/oauth/start` redirects user to Google OAuth consent screen with scopes:
+  - `https://www.googleapis.com/auth/calendar.readonly`
+  - `https://www.googleapis.com/auth/gmail.readonly`
+- [ ] GET `/oauth/callback?code=...` exchanges code for tokens (access token + refresh token)
+- [ ] Tokens stored in `settings` table: keys `google_access_token` and `google_refresh_token`
+- [ ] Tokens are never logged or exposed in HTTP responses
+- [ ] GET `/oauth/disconnect` revokes token via Google API and clears both keys from settings
+- [ ] File `public/settings.html` has a "Connect Google" button (GET `/oauth/start`) and "Disconnect" button (GET `/oauth/disconnect`)
+- [ ] After successful connect: redirect to `/settings` with message "Google connected successfully"
+- [ ] After successful disconnect: redirect to `/settings` with message "Google disconnected"
+- [ ] Token auto-refresh: if access token expires, automatically request new one using refresh token
+
+**Implementation in src/routes/oauth.js:**
+```javascript
+const express = require('express');
+const { google } = require('googleapis');
+const db = require('../db/database');
+
+const router = express.Router();
+const oauth2Client = new google.auth.OAuth2(
+  process.env.GOOGLE_CLIENT_ID,
+  process.env.GOOGLE_CLIENT_SECRET,
+  process.env.GOOGLE_REDIRECT_URI
+);
+
+router.get('/start', (req, res) => {
+  const authUrl = oauth2Client.generateAuthUrl({
+    access_type: 'offline',
+    scope: [
+      'https://www.googleapis.com/auth/calendar.readonly',
+      'https://www.googleapis.com/auth/gmail.readonly'
+    ]
+  });
+  res.redirect(authUrl);
+});
+
+router.get('/callback', async (req, res) => {
+  const { code } = req.query;
+  const { tokens } = await oauth2Client.getToken(code);
+  
+  db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)').run(
+    'google_access_token',
+    tokens.access_token
+  );
+  if (tokens.refresh_token) {
+    db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)').run(
+      'google_refresh_token',
+      tokens.refresh_token
+    );
+  }
+  
+  res.redirect('/settings?message=Google%20connected%20successfully');
+});
+
+router.get('/disconnect', async (req, res) => {
+  db.prepare('DELETE FROM settings WHERE key IN (?, ?)').run(
+    'google_access_token',
+    'google_refresh_token'
+  );
+  res.redirect('/settings?message=Google%20disconnected');
+});
+
+module.exports = router;
+```
+
+**Test command:**
+```bash
+npm start
+# Open http://localhost:3000/settings
+# Click "Connect Google", complete OAuth flow
+# Check database: sqlite3 pulse.db "SELECT * FROM settings WHERE key LIKE 'google%';"
+# Expected: rows with access_token and refresh_token values
+```
 
 ---
 
 ### [CONNECT-002] Google Calendar connector — fetch next 48h events
-**Epic:** CONNECT  
 **Priority:** Critical  
 **Effort:** M  
 **Status:** Open  
 
-Pull upcoming calendar events and store them in SQLite for use by the briefing engine and dashboard.
+Pull upcoming calendar events every 15 minutes and store them in SQLite.
 
-Acceptance criteria:
-- [ ] Fetches all events from now → +48 hours using `googleapis` npm package
-- [ ] Events stored/upserted into `events` table (no duplicates on re-sync)
-- [ ] Sync runs every 15 minutes via `node-cron`
-- [ ] If Google API returns an error, log it and use cached data — no crash
-- [ ] Multi-calendar support: fetches from all calendars in the user's account
-- [ ] Recurring events resolved to individual instances (not just the parent)
+**Acceptance criteria:**
+- [ ] File `src/connectors/calendar.js` exists and exports function `syncCalendarEvents(db, oauth2Client)`
+- [ ] Function fetches all events from `now` → `now + 48 hours` using `calendar.events.list()`
+- [ ] Events stored in `events` table via upsert: if `id` exists, update; otherwise insert
+- [ ] Each event stored with: `id` (Google's event ID), `title`, `start_time`, `end_time`, `location`, `calendar_id`, `synced_at`
+- [ ] `start_time` and `end_time` are Unix timestamps (seconds since epoch)
+- [ ] Multi-calendar support: fetches from all calendars in user's account (not just primary)
+- [ ] Recurring events resolved to individual instances (not parent event)
+- [ ] Function includes error handling: if Google API call fails, logs error and returns early (no crash)
+- [ ] cron job in `src/cron/index.js` calls this function every 15 minutes (runs regardless of auth status)
+- [ ] If no Google token in settings, function skips silently and logs "No Google token, skipping calendar sync"
+- [ ] Database updates `settings.last_calendar_sync` to current timestamp after successful sync
+
+**Implementation in src/connectors/calendar.js:**
+```javascript
+const { google } = require('googleapis');
+
+async function syncCalendarEvents(db, oauth2Client) {
+  const accessToken = db.prepare('SELECT value FROM settings WHERE key = ?').get('google_access_token')?.value;
+  if (!accessToken) {
+    console.log('No Google token, skipping calendar sync');
+    return;
+  }
+
+  oauth2Client.setCredentials({ access_token: accessToken });
+  const calendar = google.calendar({ version: 'v3', auth: oauth2Client });
+
+  try {
+    const now = new Date();
+    const in48h = new Date(now.getTime() + 48 * 60 * 60 * 1000);
+
+    const { data } = await calendar.calendarList.list();
+    const calendarIds = data.items.map(cal => cal.id);
+
+    for (const calendarId of calendarIds) {
+      const { data: events } = await calendar.events.list({
+        calendarId,
+        timeMin: now.toISOString(),
+        timeMax: in48h.toISOString(),
+        singleEvents: true,
+        orderBy: 'startTime'
+      });
+
+      for (const event of events.items || []) {
+        const startTime = new Date(event.start.dateTime || event.start.date).getTime() / 1000;
+        const endTime = new Date(event.end.dateTime || event.end.date).getTime() / 1000;
+
+        db.prepare(`
+          INSERT OR REPLACE INTO events (id, title, start_time, end_time, location, calendar_id, synced_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `).run(event.id, event.summary, Math.floor(startTime), Math.floor(endTime), event.location || null, calendarId, Math.floor(Date.now() / 1000));
+      }
+    }
+
+    db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)').run('last_calendar_sync', Math.floor(Date.now() / 1000));
+  } catch (err) {
+    console.error('Calendar sync error:', err.message);
+  }
+}
+
+module.exports = { syncCalendarEvents };
+```
+
+**Test command:**
+```bash
+npm start
+# Wait for first 15-min sync or trigger manually
+sqlite3 pulse.db "SELECT COUNT(*) FROM events;"
+# Expected: > 0 (if you have upcoming calendar events)
+```
 
 ---
 
 ### [CONNECT-003] Gmail connector — fetch and flag important unread emails
-**Epic:** CONNECT  
 **Priority:** Critical  
 **Effort:** M  
 **Status:** Open  
 
-Pull recent unread emails and use Claude Haiku to flag the ones that look important.
+Pull unread emails every 15 minutes and use Ollama to score importance.
 
-Acceptance criteria:
-- [ ] Fetches up to 50 unread emails from last 24 hours using Gmail API
-- [ ] Emails stored/upserted into `emails` table
-- [ ] Flagging logic: emails from known senders (past 30 days), emails with keywords ("urgent", "action", "deadline", "invoice", "meeting") are auto-flagged
-- [ ] Claude Haiku used to score remaining emails — "important" vs "routine"
-- [ ] Only flagged emails shown in the dashboard feed by default
-- [ ] Sync runs every 15 minutes via `node-cron`
+**Acceptance criteria:**
+- [ ] Dependencies installed: `axios@1.6.0` (for Ollama HTTP calls)
+- [ ] File `src/connectors/gmail.js` exists and exports function `syncGmailEmails(db, oauth2Client)`
+- [ ] Function fetches up to 50 unread emails from last 24 hours using Gmail API
+- [ ] Flagging logic:
+  - Auto-flag if sender is in the list of senders from past 30 days (known sender)
+  - Auto-flag if subject or snippet contains keywords: "urgent", "action", "deadline", "invoice", "review", "meeting"
+  - Otherwise: send to Ollama for scoring
+- [ ] Ollama call to `http://localhost:11434/v1/chat/completions`:
+  ```json
+  {
+    "model": "gemma4:e4b",
+    "messages": [
+      { "role": "system", "content": "You are an email importance classifier." },
+      { "role": "user", "content": "Is this email important or routine?\n\nSubject: {subject}\nFrom: {sender}\nSnippet: {snippet}\n\nRespond with only one word: important or routine" }
+    ],
+    "temperature": 0.3,
+    "stream": false
+  }
+  ```
+  - Parse response: if text includes "important" → flag email
+- [ ] Emails stored in `emails` table via upsert: id, subject, sender, received_at, snippet, is_flagged
+- [ ] `received_at` is Unix timestamp
+- [ ] `snippet` is first 200 characters of email body
+- [ ] Function includes error handling: if Ollama fails, log error and skip email (don't crash)
+- [ ] Function includes error handling: if Gmail API fails, log error and return early
+- [ ] cron job calls this function every 15 minutes
+- [ ] If no Google token, function skips silently
+- [ ] Settings table updated: `last_gmail_sync` to current timestamp after successful sync
+
+**Implementation in src/connectors/gmail.js:**
+```javascript
+const { google } = require('googleapis');
+const axios = require('axios');
+
+async function scoreEmailImportance(subject, sender, snippet) {
+  try {
+    const response = await axios.post(`${process.env.OLLAMA_BASE_URL}/v1/chat/completions`, {
+      model: process.env.OLLAMA_MODEL,
+      messages: [
+        { role: 'system', content: 'You are an email importance classifier.' },
+        { role: 'user', content: `Is this email important or routine?\n\nSubject: ${subject}\nFrom: ${sender}\nSnippet: ${snippet}\n\nRespond with only one word: important or routine` }
+      ],
+      temperature: 0.3,
+      stream: false
+    }, { timeout: 5000 });
+
+    const text = response.data.choices[0].message.content.toLowerCase();
+    return text.includes('important');
+  } catch (err) {
+    console.error('Ollama scoring error:', err.message);
+    return false;
+  }
+}
+
+async function syncGmailEmails(db, oauth2Client) {
+  const accessToken = db.prepare('SELECT value FROM settings WHERE key = ?').get('google_access_token')?.value;
+  if (!accessToken) {
+    console.log('No Google token, skipping Gmail sync');
+    return;
+  }
+
+  oauth2Client.setCredentials({ access_token: accessToken });
+  const gmail = google.gmail({ version: 'v1', auth: oauth2Client });
+
+  try {
+    const { data } = await gmail.users.messages.list({
+      userId: 'me',
+      q: 'is:unread after:2d',
+      maxResults: 50
+    });
+
+    const messages = data.messages || [];
+    const keywords = ['urgent', 'action', 'deadline', 'invoice', 'review', 'meeting'];
+    const knownSenders = new Set();
+
+    // Build set of known senders from past 30 days
+    const thirtyDaysAgo = Math.floor((Date.now() - 30*24*60*60*1000) / 1000);
+    const past30Emails = db.prepare('SELECT DISTINCT sender FROM emails WHERE received_at > ?').all(thirtyDaysAgo);
+    past30Emails.forEach(row => knownSenders.add(row.sender));
+
+    for (const msg of messages) {
+      const { data: full } = await gmail.users.messages.get({ userId: 'me', id: msg.id, format: 'full' });
+      const headers = full.payload.headers;
+      const subject = headers.find(h => h.name === 'Subject')?.value || '(no subject)';
+      const sender = headers.find(h => h.name === 'From')?.value || '(no sender)';
+      const snippet = full.snippet.substring(0, 200);
+      const receivedAt = Math.floor(full.internalDate / 1000);
+
+      // Auto-flag logic
+      let isFlagged = knownSenders.has(sender);
+      if (!isFlagged) {
+        isFlagged = keywords.some(kw => subject.toLowerCase().includes(kw) || snippet.toLowerCase().includes(kw));
+      }
+      if (!isFlagged) {
+        isFlagged = await scoreEmailImportance(subject, sender, snippet);
+      }
+
+      db.prepare(`
+        INSERT OR REPLACE INTO emails (id, subject, sender, received_at, snippet, is_flagged)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(msg.id, subject, sender, receivedAt, snippet, isFlagged ? 1 : 0);
+    }
+
+    db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)').run('last_gmail_sync', Math.floor(Date.now() / 1000));
+  } catch (err) {
+    console.error('Gmail sync error:', err.message);
+  }
+}
+
+module.exports = { syncGmailEmails };
+```
+
+**Test command:**
+```bash
+npm start
+# (requires Ollama running on localhost:11434 with gemma4:e4b pulled)
+# Wait for first 15-min sync or trigger manually
+sqlite3 pulse.db "SELECT COUNT(*) FROM emails WHERE is_flagged = 1;"
+# Expected: > 0 (if you have unread emails)
+```
 
 ---
 
-### [CONNECT-004] Source connection status tracking
-**Epic:** CONNECT  
-**Priority:** High  
-**Effort:** XS  
-**Status:** Open  
+## BRIEF Epic
 
-Track the health of each data source connection so the status bar can display accurate sync state.
-
-Acceptance criteria:
-- [ ] `settings` table stores `last_calendar_sync`, `last_gmail_sync` timestamps
-- [ ] `last_sync_status` per source: `ok`, `error`, `never`
-- [ ] Status bar on dashboard reads from these values
-- [ ] If last sync > 30 minutes ago, status bar shows a warning (not an error screen)
-
----
-
-### [BRIEF-001] Claude Haiku briefing prompt + response parser
-**Epic:** BRIEF  
+### [BRIEF-001] Ollama briefing engine — generate morning briefing
 **Priority:** Critical  
 **Effort:** M  
 **Status:** Open  
 
-Build the core briefing generation logic using Claude Haiku. Given a structured input of events and flagged emails, produce a concise, plain-language briefing.
+Core briefing generation: pull events + flagged emails, call Ollama, store result.
 
-Acceptance criteria:
-- [ ] Prompt is stored in `lib/briefing/prompt.js` and can be updated without code changes
-- [ ] Input: array of events (today + tomorrow) + array of flagged emails
-- [ ] Output: plain text paragraph(s), max ~200 words, conversational tone
-- [ ] Response parser extracts the briefing text and stores it in the `briefings` table
-- [ ] If Claude API call fails, fallback is a structured plain-text summary (event titles + email subjects)
-- [ ] API key stored in `.env` as `ANTHROPIC_API_KEY`
+**Acceptance criteria:**
+- [ ] File `src/engines/briefing.js` exists and exports async function `generateBriefing(db)`
+- [ ] Function queries events WHERE `start_time BETWEEN now AND now+48h` from events table
+- [ ] Function queries emails WHERE `is_flagged=1 AND received_at > now-24h` from emails table
+- [ ] Function builds structured prompt:
+  ```
+  You are a morning briefing generator for a busy professional.
+
+  Here are today's calendar events and flagged emails. Generate a brief, conversational morning briefing (max 150 words) that highlights what needs attention. Do not list raw data — synthesize it into prose.
+
+  CALENDAR EVENTS (today and tomorrow):
+  [formatted list of events with times]
+
+  FLAGGED EMAILS (last 24 hours):
+  [formatted list of emails with sender + subject]
+
+  Generate the briefing:
+  ```
+- [ ] Function calls Ollama at `http://localhost:11434/v1/chat/completions`:
+  - model: from `process.env.OLLAMA_MODEL`
+  - messages: system prompt + user prompt above
+  - temperature: 0.7
+  - max_tokens: 300
+- [ ] Response text extracted and stored in `briefings` table: `INSERT INTO briefings (generated_at, content_raw) VALUES (?, ?)`
+- [ ] `generated_at` is Unix timestamp
+- [ ] If Ollama call fails (timeout, no model, error): generate fallback briefing (structured list, no AI)
+  ```
+  FALLBACK BRIEFING:
+  Today's events:
+  [event titles with times]
+  
+  Flagged emails:
+  [sender + subject]
+  ```
+- [ ] Function returns briefing text as string
+- [ ] Function includes error logging but does not crash or throw
+
+**Implementation in src/engines/briefing.js:**
+```javascript
+const axios = require('axios');
+const db = require('../db/database');
+
+async function generateBriefing(db) {
+  const now = Math.floor(Date.now() / 1000);
+  const tomorrow = now + 24 * 60 * 60;
+  const in48h = now + 48 * 60 * 60;
+
+  const events = db.prepare(`
+    SELECT title, start_time, end_time FROM events
+    WHERE start_time BETWEEN ? AND ?
+    ORDER BY start_time
+  `).all(now, in48h);
+
+  const emails = db.prepare(`
+    SELECT sender, subject FROM emails
+    WHERE is_flagged = 1 AND received_at > ?
+    ORDER BY received_at DESC
+  `).all(now - 24*60*60);
+
+  const eventStr = events.map(e => {
+    const start = new Date(e.start_time * 1000).toLocaleTimeString();
+    return `- ${e.title} at ${start}`;
+  }).join('\n') || '(no events)';
+
+  const emailStr = emails.map(e => `- From ${e.sender}: ${e.subject}`).join('\n') || '(no flagged emails)';
+
+  const userPrompt = `You are a morning briefing generator. Create a brief, conversational briefing (max 150 words).
+
+CALENDAR EVENTS (next 48 hours):
+${eventStr}
+
+FLAGGED EMAILS (last 24 hours):
+${emailStr}
+
+Generate the briefing:`;
+
+  try {
+    const response = await axios.post(`${process.env.OLLAMA_BASE_URL}/v1/chat/completions`, {
+      model: process.env.OLLAMA_MODEL,
+      messages: [
+        { role: 'system', content: 'You are a morning briefing generator for a busy professional.' },
+        { role: 'user', content: userPrompt }
+      ],
+      temperature: 0.7,
+      max_tokens: 300,
+      stream: false
+    }, { timeout: 10000 });
+
+    const briefing = response.data.choices[0].message.content;
+    db.prepare('INSERT INTO briefings (generated_at, content_raw) VALUES (?, ?)').run(now, briefing);
+    return briefing;
+  } catch (err) {
+    console.error('Ollama briefing error:', err.message);
+    
+    // Fallback briefing
+    const fallback = `MORNING BRIEFING (generated offline)\n\nToday's events:\n${eventStr}\n\nFlagged emails:\n${emailStr}`;
+    db.prepare('INSERT INTO briefings (generated_at, content_raw) VALUES (?, ?)').run(now, fallback);
+    return fallback;
+  }
+}
+
+module.exports = { generateBriefing };
+```
+
+**Test command:**
+```bash
+npm start
+# (requires Ollama running and model pulled)
+node -e "
+  const db = require('./db/database');
+  const { generateBriefing } = require('./src/engines/briefing');
+  generateBriefing(db).then(b => console.log(b));
+"
+```
 
 ---
 
-### [BRIEF-002] Morning briefing cron job (7:00am daily)
-**Epic:** BRIEF  
+## UI Epic (Minimal for MVP)
+
+### [UI-001] Public/index.html — Dashboard 3-panel layout
 **Priority:** Critical  
-**Effort:** S  
-**Status:** Open  
-
-Schedule the morning briefing to generate and deliver every day at 7:00am.
-
-Acceptance criteria:
-- [ ] `node-cron` job fires at 7:00am local time (configured via `BRIEFING_TIME` env var)
-- [ ] Job pulls latest events + flagged emails from SQLite
-- [ ] Calls briefing generator, stores result in `briefings` table
-- [ ] Triggers a browser push notification via Web Push API: "Your morning briefing is ready"
-- [ ] Optionally sends SMS via Twilio if `TWILIO_ENABLED=true` in `.env`
-- [ ] If briefing generation fails, fallback briefing is generated and stored — job never silently dies
-
----
-
-### [BRIEF-003] Twilio SMS delivery (optional)
-**Epic:** BRIEF  
-**Priority:** Medium  
-**Effort:** S  
-**Status:** Open  
-
-Add optional SMS delivery of the morning briefing via Twilio.
-
-Acceptance criteria:
-- [ ] Controlled by `TWILIO_ENABLED=true` in `.env`
-- [ ] Required env vars: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`, `TWILIO_TO_NUMBER`
-- [ ] SMS text is a truncated version of the briefing (≤320 chars)
-- [ ] If Twilio fails, log error — do not crash the briefing job
-- [ ] Setup instructions in README under "Optional: SMS Briefing"
-
----
-
-### [BRIEF-004] Briefing history — store and retrieve past briefings
-**Epic:** BRIEF  
-**Priority:** High  
-**Effort:** S  
-**Status:** Open  
-
-Store all generated briefings so users can look back at past mornings.
-
-Acceptance criteria:
-- [ ] `briefings` table stores: id, generated_at, content_raw, content_html
-- [ ] GET `/api/briefings` returns last 14 briefings (paginated)
-- [ ] Dashboard displays the most recent briefing prominently, with a "History" toggle to see past ones
-- [ ] Each briefing card shows date/time generated and content
-
----
-
-### [NUDGE-001] Nudge engine — 2-hour event reminder
-**Epic:** NUDGE  
-**Priority:** Critical  
-**Effort:** M  
-**Status:** Open  
-
-Detect upcoming events and send a calm browser notification 2 hours before they start.
-
-Acceptance criteria:
-- [ ] Cron job runs every 5 minutes, checks for events starting in 115–125 minutes
-- [ ] If user opened dashboard in last 30 minutes, skip nudge (they already know)
-- [ ] If daily nudge limit (3) is reached, skip and log
-- [ ] Browser push notification text: "You have [event title] in 2 hours."
-- [ ] Nudge recorded in `nudges` table: event_id, nudge_type=`2hr`, sent_at
-- [ ] Same event never nudged twice for the same nudge_type
-
----
-
-### [NUDGE-002] Nudge engine — 30-minute event reminder
-**Epic:** NUDGE  
-**Priority:** Critical  
-**Effort:** S  
-**Status:** Open  
-
-Send a nudge 30 minutes before an event starts.
-
-Acceptance criteria:
-- [ ] Cron job checks for events starting in 25–35 minutes
-- [ ] Same skip logic as NUDGE-001 (last-opened check, daily limit)
-- [ ] Notification text: "Starting in 30 minutes: [event title]"
-- [ ] Nudge recorded in `nudges` table with nudge_type=`30min`
-- [ ] If both 2hr and 30min nudges would fire for the same event on a limit-reached day, prefer the 30-minute one
-
----
-
-### [NUDGE-003] Web Push notification setup (VAPID)
-**Epic:** NUDGE  
-**Priority:** Critical  
-**Effort:** M  
-**Status:** Open  
-
-Set up Web Push (VAPID) so the browser can receive push notifications from the local server, even when the tab isn't focused.
-
-Acceptance criteria:
-- [ ] VAPID keys generated and stored in `.env`
-- [ ] Service worker registered in the browser on first dashboard load
-- [ ] User prompted once to allow notifications
-- [ ] `web-push` npm package used on the server side
-- [ ] Push subscription stored in `settings` table
-- [ ] Test push notification available via GET `/api/nudge/test`
-
----
-
-### [NUDGE-004] Daily nudge quota tracking
-**Epic:** NUDGE  
-**Priority:** High  
-**Effort:** XS  
-**Status:** Open  
-
-Track how many nudges have been sent today and enforce the daily maximum (default: 3).
-
-Acceptance criteria:
-- [ ] Nudge count resets at midnight via cron job
-- [ ] Count stored in `settings` table: `nudges_sent_today`
-- [ ] All nudge jobs check this count before sending
-- [ ] Status bar shows "Nudges today: 2/3" so user has visibility
-- [ ] Max configurable via `settings` table key `nudges_per_day`
-
----
-
-### [UI-001] Dashboard layout — three-panel feed
-**Epic:** UI  
-**Priority:** Critical  
-**Effort:** M  
-**Status:** Open  
-
-Build the main dashboard layout with the three panels: today's feed, morning briefing card, and status bar.
-
-Acceptance criteria:
-- [ ] Pure HTML/CSS/JS — no build step, no frameworks, no bundler
-- [ ] Responsive layout: single column on mobile, two columns on desktop
-- [ ] Panel 1: Today's Feed — chronological list of upcoming events + flagged emails for next 48h
-- [ ] Panel 2: Morning Briefing card — latest briefing content, "History" link
-- [ ] Panel 3: Status bar — last sync time per source, nudges today count, connection indicators
-- [ ] Auto-refreshes every 5 minutes without full page reload (fetch + DOM update)
-- [ ] Loads in under 2 seconds on localhost
-
----
-
-### [UI-002] Upcoming events panel
-**Epic:** UI  
-**Priority:** Critical  
-**Effort:** S  
-**Status:** Open  
-
-Display upcoming calendar events for the next 48 hours in the feed.
-
-Acceptance criteria:
-- [ ] Events displayed in chronological order
-- [ ] Each event shows: title, start time, duration, location (if present)
-- [ ] "Today" vs "Tomorrow" section dividers
-- [ ] Events starting within 2 hours highlighted visually (e.g., accent color)
-- [ ] If no events in next 48h, show "Nothing on the calendar — you're clear."
-- [ ] Data pulled from GET `/api/events` endpoint
-
----
-
-### [UI-003] Flagged emails panel
-**Epic:** UI  
-**Priority:** Critical  
-**Effort:** S  
-**Status:** Open  
-
-Display flagged emails in the feed with enough context to act on them without opening Gmail.
-
-Acceptance criteria:
-- [ ] Shows sender name/address, subject, time received, and snippet (first 100 chars)
-- [ ] Sorted by received time (newest first)
-- [ ] Clicking an email opens it in Gmail (new tab) via direct link
-- [ ] "Mark as reviewed" button removes it from the feed (sets `is_flagged=false` locally)
-- [ ] If no flagged emails, show "Inbox looks quiet."
-- [ ] Data pulled from GET `/api/emails/flagged`
-
----
-
-### [UI-004] Login page
-**Epic:** UI  
-**Priority:** Critical  
-**Effort:** XS  
-**Status:** Open  
-
-Simple password-gated login page. Minimal design.
-
-Acceptance criteria:
-- [ ] Single password field, submit button
-- [ ] On success: session cookie set, redirect to dashboard
-- [ ] On failure: inline error "Wrong password. Try again." — no redirect
-- [ ] No username field — single user only
-- [ ] Works on mobile
-
----
-
-### [UI-005] Source connection settings page
-**Epic:** UI  
-**Priority:** High  
-**Effort:** S  
-**Status:** Open  
-
-A simple settings page where the user can connect or disconnect Google Calendar and Gmail.
-
-Acceptance criteria:
-- [ ] Accessible at `/settings`
-- [ ] Shows connection status for each source (connected / not connected)
-- [ ] "Connect Google" button triggers OAuth flow
-- [ ] "Disconnect" button revokes token and clears stored credentials
-- [ ] After connecting, redirects back to dashboard with a success message
-- [ ] No other settings on this page in MVP (nudge limits, themes etc. are future)
-
----
-
-### [INFRA-001] Health check endpoint
-**Epic:** INFRA  
-**Priority:** High  
-**Effort:** XS  
-**Status:** Open  
-
-A simple health check endpoint for monitoring and process management.
-
-Acceptance criteria:
-- [ ] GET `/health` returns JSON: `{ status: "ok", uptime: <seconds>, db: "ok"|"error", lastSync: { calendar: ..., gmail: ... } }`
-- [ ] Returns HTTP 200 if healthy, HTTP 503 if database is unreachable
-- [ ] Used by `pm2` for auto-restart decisions
-
----
-
-### [INFRA-002] Deploy script for Mac Studio
-**Epic:** INFRA  
-**Priority:** High  
-**Effort:** S  
-**Status:** Open  
-
-A simple deploy/start script so Pulse runs persistently on the Mac Studio as a background service.
-
-Acceptance criteria:
-- [ ] `scripts/start.sh` installs dependencies, initializes DB, and starts the server via `pm2`
-- [ ] Pulse auto-starts on system boot (pm2 startup hook)
-- [ ] `scripts/stop.sh` stops the pm2 process cleanly
-- [ ] `scripts/logs.sh` tails the pm2 log file
-- [ ] README includes "Running Pulse on Mac Studio" section with step-by-step instructions
-
----
-
-### [INFRA-003] README setup guide
-**Epic:** INFRA  
-**Priority:** High  
-**Effort:** S  
-**Status:** Open  
-
-A complete, accurate README that lets someone set up Pulse from scratch in under 15 minutes.
-
-Acceptance criteria:
-- [ ] Prerequisites listed: Node.js version, Google Cloud project, Anthropic API key
-- [ ] Step-by-step: clone → `.env` setup → `npm install` → `npm start`
-- [ ] Google OAuth setup instructions (how to create the Cloud project, enable APIs, set redirect URI)
-- [ ] Optional Twilio setup section
-- [ ] Troubleshooting section: common errors and fixes
-- [ ] Screenshots of the dashboard (added after UI is built)
-
----
-
-### [BIZ-001] Business version — team brain architecture design
-**Epic:** BIZ  
-**Priority:** Low  
-**Effort:** XL  
-**Status:** Open  
-
-Design the architecture for the business version of Pulse — a company-wide brain plus per-employee sub-brains.
-
-This is a research and design spike, not implementation. Output is a design doc.
-
-Acceptance criteria:
-- [ ] `docs/BIZ_ARCHITECTURE.md` created with proposed architecture
-- [ ] Covers: multi-user auth, shared company context (shared calendar, announcements), per-employee private context
-- [ ] Addresses: data isolation between employees, admin vs member roles, how briefings differ for managers vs ICs
-- [ ] Identifies the biggest technical risks and open questions
-- [ ] Does NOT block or depend on any MVP work
-
----
-
-### [BIZ-002] Business version — per-employee sub-brain concept
-**Epic:** BIZ  
-**Priority:** Low  
 **Effort:** L  
 **Status:** Open  
 
-Define what a "per-employee sub-brain" looks like — its data sources, its briefing style, its relationship to the company brain.
+Build the main dashboard. Three panels: feed, briefing, status. Pure HTML/CSS/JS.
 
-Acceptance criteria:
-- [ ] Design doc added to `docs/BIZ_EMPLOYEE_BRAIN.md`
-- [ ] Covers: what data sources are private vs shared, how the briefing blends personal + company context
-- [ ] Proposes UI: does each employee have their own dashboard? Or one shared dashboard with roles?
-- [ ] Lists the minimum viable set of features for a 5-person team pilot
+**File structure:**
+- `public/index.html` — main HTML (serve via GET `/`)
+- `public/style.css` — all styles
+- `public/dashboard.js` — polls API and updates DOM every 5 min
+
+**Acceptance criteria:**
+- [ ] `public/index.html` is valid HTML5, links stylesheet and JS, no build step
+- [ ] Layout: three columns on desktop (feed 60% | briefing 40%), single column on mobile
+- [ ] Panel 1 "Today's Feed": 
+  - Chronological list of next 48h events + flagged emails
+  - Each event: title, start time, duration, location (if exists)
+  - Each email: sender, subject, time received
+  - Sections for "Today" vs "Tomorrow"
+  - Empty states: "Nothing on the calendar — you're clear."
+- [ ] Panel 2 "Morning Briefing":
+  - Latest briefing card with time generated
+  - "History" link to see past briefings
+  - If no briefing yet: "Your briefing will be ready at 7:00 AM"
+- [ ] Panel 3 "Status Bar":
+  - Last sync time per source (Calendar, Gmail)
+  - Nudges sent today: "2/3"
+  - Connection indicators: green dot = synced within 30 min, yellow = > 30 min, red = never
+- [ ] Dashboard fetches data every 5 minutes from:
+  - GET `/api/events` → returns JSON array of upcoming events
+  - GET `/api/emails/flagged` → returns JSON array of flagged emails
+  - GET `/api/briefings/latest` → returns latest briefing or null
+  - GET `/api/status` → returns `{ lastCalendarSync, lastGmailSync, nudigts_sent_today }`
+- [ ] Auto-refresh updates the DOM without full page reload (vanilla JS fetch + DOM manipulation)
+- [ ] All times displayed in user's local timezone
+- [ ] Loads in under 2 seconds on localhost (test with DevTools Network tab)
+- [ ] Mobile-responsive: works on 375px width (test with iPhone SE viewport)
+- [ ] No frameworks: vanilla HTML/CSS/JS only
+
+**public/dashboard.js outline:**
+```javascript
+async function fetchAndUpdate() {
+  const events = await fetch('/api/events').then(r => r.json());
+  const emails = await fetch('/api/emails/flagged').then(r => r.json());
+  const briefing = await fetch('/api/briefings/latest').then(r => r.json());
+  const status = await fetch('/api/status').then(r => r.json());
+
+  // Update DOM based on data
+  document.getElementById('feed').innerHTML = /* ... */;
+  document.getElementById('briefing').innerHTML = /* ... */;
+  document.getElementById('status-bar').innerHTML = /* ... */;
+}
+
+// Auto-refresh every 5 minutes
+fetchAndUpdate();
+setInterval(fetchAndUpdate, 5 * 60 * 1000);
+```
+
+**Test command:**
+```bash
+npm start
+# Open http://localhost:3000 in browser (after login)
+# Check that feed, briefing, status render
+# Use DevTools → Network to verify < 2 second load
+```
 
 ---
 
-### [BIZ-003] Native mobile / watch app research spike
-**Epic:** BIZ  
-**Priority:** Low  
-**Effort:** M  
+## INFRA Epic
+
+### [INFRA-001] Deploy script for Mac Studio
+**Priority:** High  
+**Effort:** S  
 **Status:** Open  
 
-Research the feasibility and approach for a native mobile or Apple Watch app as a delivery surface for Pulse nudges.
+Simple script to get Pulse running persistently on Mac.
 
-Acceptance criteria:
-- [ ] `docs/NATIVE_APP_SPIKE.md` created
-- [ ] Covers React Native vs Swift/Kotlin native vs PWA tradeoffs
-- [ ] Covers Watch OS notification delivery constraints
-- [ ] Estimates effort for a basic nudge-delivery-only native app
-- [ ] Identifies blockers (e.g., App Store distribution, push notification infra changes)
+**Acceptance criteria:**
+- [ ] File `scripts/start.sh` exists at project root
+- [ ] `scripts/start.sh` does:
+  1. `npm install` (installs deps)
+  2. Checks if Ollama is running on `http://localhost:11434` (curl `/api/health`), fails if not
+  3. Checks if model is available: `ollama list | grep gemma4:e4b`, fails if not
+  4. Initializes DB: `node -e "require('./db/database')"`
+  5. Starts Pulse via `pm2 start server.js --name pulse --instances 1 --error /tmp/pulse-error.log --out /tmp/pulse-out.log`
+  6. Output: "Pulse started. View logs: pm2 logs pulse"
+- [ ] File `scripts/stop.sh` runs `pm2 stop pulse && pm2 delete pulse`
+- [ ] File `scripts/logs.sh` runs `pm2 logs pulse`
+- [ ] Dependencies installed: `pm2@5.3.0` (globally: `npm install -g pm2@5.3.0`)
+- [ ] `pm2 startup` configured to auto-start on system boot (run once manually after first `scripts/start.sh`)
+- [ ] README includes "Running Pulse on Mac Studio" section with instructions
+
+**scripts/start.sh content:**
+```bash
+#!/bin/bash
+set -e
+
+echo "Installing dependencies..."
+npm install
+
+echo "Checking Ollama..."
+if ! curl -s http://localhost:11434/api/health > /dev/null; then
+  echo "ERROR: Ollama not running on http://localhost:11434"
+  echo "Start Ollama first: ollama serve"
+  exit 1
+fi
+
+echo "Checking model..."
+if ! ollama list | grep -q gemma4:e4b; then
+  echo "ERROR: gemma4:e4b not found. Pull it first:"
+  echo "  ollama pull gemma4:e4b"
+  exit 1
+fi
+
+echo "Initializing database..."
+node -e "require('./db/database')"
+
+echo "Starting Pulse..."
+pm2 start server.js --name pulse --instances 1 --error /tmp/pulse-error.log --out /tmp/pulse-out.log
+
+echo "Pulse started. View logs: pm2 logs pulse"
+echo ""
+echo "To enable auto-start on boot:"
+echo "  pm2 startup"
+echo "  pm2 save"
+```
+
+**Test command:**
+```bash
+chmod +x scripts/start.sh scripts/stop.sh scripts/logs.sh
+./scripts/start.sh
+pm2 logs pulse
+# Should show server logs
+./scripts/stop.sh
+```
+
+---
+
+### [INFRA-002] README setup guide
+**Priority:** High  
+**Effort:** S  
+**Status:** Open  
+
+Complete README so someone can set up Pulse from scratch in 15 minutes.
+
+**Sections to include:**
+1. **What is Pulse** — one paragraph description
+2. **Prerequisites** — Node.js 18+, Ollama, Google Cloud project
+3. **Quick Start** — step by step:
+   - `git clone https://github.com/davidlonski/pulse.git && cd pulse`
+   - Create Google OAuth app and get credentials
+   - Copy `.env.example` to `.env` and fill in values
+   - `./scripts/start.sh`
+   - Open http://localhost:3000
+4. **Google OAuth Setup** — instructions to create Cloud project, enable APIs, set redirect URI
+5. **Ollama Setup** — install Ollama, pull `gemma4:e4b`
+6. **Environment Variables** — table of all vars, required vs optional
+7. **Troubleshooting** — common errors:
+   - "Ollama not running" → how to start
+   - "Google token invalid" → how to reconnect
+   - "Database locked" → rm pulse.db and restart
+8. **Architecture** — link to `docs/ARCHITECTURE.md`
+9. **Backlog** — link to `BACKLOG.md`
+
+**Test command:**
+```bash
+# Have someone new follow the README steps
+# Should be able to get Pulse running in < 15 minutes
+```
+
+---
+
+## Notes for Cursor
+
+- Each issue is executable end-to-end
+- Exact file paths, exact npm versions, exact commands
+- Acceptance criteria are verifiable (test commands provided)
+- Dependencies listed explicitly (version pinned)
+- SQL and JavaScript code samples provided — use as starting point, adapt as needed
+- If something is unclear, ask; don't guess
+- Commit after each issue completion: `git add . && git commit -m "[EPIC-NNN] description"`
+- Push to `davidlonski/pulse` after every few issues

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,9 +46,9 @@ High-level design of how Pulse is built, how data flows through it, and why the 
 │  │   Engine     │ │   Engine     │ │   (Express)     │            │
 │  │              │ │              │ │                 │            │
 │  │ 7am cron     │ │ 5min cron    │ │ /api/events     │            │
-│  │ Claude Haiku │ │ 2hr + 30min  │ │ /api/emails     │            │
-│  │ → briefings  │ │ reminders    │ │ /api/briefings  │            │
-│  │   table      │ │ → nudges tbl │ │ /health         │            │
+│  │ Ollama HTTP  │ │ 2hr + 30min  │ │ /api/emails     │            │
+│  │ (port 11434) │ │ reminders    │ │ /api/briefings  │            │
+│  │ → briefings  │ │ → nudges tbl │ │ /health         │            │
 │  └──────┬───────┘ └──────┬───────┘ └────────┬────────┘            │
 │         │                │                  │                      │
 └─────────┼────────────────┼──────────────────┼──────────────────────┘
@@ -68,6 +68,69 @@ High-level design of how Pulse is built, how data flows through it, and why the 
 │   │   Morning briefing only │                                        │
 │   └────────────────────────┘                                        │
 └─────────────────────────────────────────────────────────────────────┘
+          │
+          ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Local LLM (Ollama)                               │
+│                                                                     │
+│   Runs on the same machine as Pulse. Pulse calls it over HTTP.      │
+│   No data leaves the machine. No API key required.                  │
+│                                                                     │
+│   Endpoint: http://localhost:11434/v1/chat/completions              │
+│   Model (briefing + email scoring): gemma4:e4b                      │
+│                                                                     │
+│   Used by:                                                          │
+│   - Briefing Engine  (morning briefing generation)                  │
+│   - Gmail Connector  (email importance scoring)                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Project File Structure
+
+This is the exact structure Pulse is built against. Every issue in BACKLOG.md references files from this tree.
+
+```
+pulse/
+├── package.json
+├── .env.example              ← All required keys, no values, committed to git
+├── .gitignore
+├── server.js                 ← Express app entry point, loads all routes + crons
+├── db/
+│   ├── init.sql              ← Full schema DDL, run on startup
+│   └── database.js           ← better-sqlite3 singleton, exported as db
+├── src/
+│   ├── connectors/
+│   │   ├── calendar.js       ← Google Calendar fetch + upsert into events table
+│   │   └── gmail.js          ← Gmail fetch + flag pass + Ollama scoring
+│   ├── engines/
+│   │   ├── briefing.js       ← Pull from SQLite, call Ollama, store in briefings
+│   │   └── nudge.js          ← Detect upcoming events, send push, record in nudges
+│   ├── cron/
+│   │   └── index.js          ← Register all node-cron jobs (sync, briefing, nudge)
+│   ├── routes/
+│   │   ├── api.js            ← GET /api/events, /api/emails/flagged, /api/briefings
+│   │   └── auth.js           ← GET/POST /login, /logout, /oauth/callback
+│   ├── push/
+│   │   └── webpush.js        ← VAPID key load, push subscription store, sendPush()
+│   └── ollama/
+│       └── client.js         ← chatCompletion(prompt, systemPrompt) → string
+├── public/
+│   ├── index.html            ← Dashboard (three-panel layout)
+│   ├── login.html            ← Password gate
+│   ├── settings.html         ← Google OAuth connect/disconnect
+│   ├── style.css
+│   ├── dashboard.js          ← Polls /api every 5 min, updates DOM
+│   └── sw.js                 ← Service worker — handles push notification display
+├── scripts/
+│   ├── start.sh              ← npm install + db init + pm2 start
+│   ├── stop.sh               ← pm2 stop pulse
+│   └── logs.sh               ← pm2 logs pulse
+└── docs/
+    ├── ARCHITECTURE.md       ← This file
+    ├── SCHEMA.md             ← Table definitions with column types (created by CORE-002)
+    └── BIZ_ARCHITECTURE.md   ← Future business version design (created by BIZ-001)
 ```
 
 ---
@@ -77,45 +140,56 @@ High-level design of how Pulse is built, how data flows through it, and why the 
 ### 1. Calendar Data
 ```
 Google Calendar API
-  → Calendar Connector (every 15 min via node-cron)
+  → src/connectors/calendar.js (every 15 min via node-cron)
   → Upsert into events table (SQLite)
-  → Read by Briefing Engine + Nudge Engine + REST API
-  → Displayed in Dashboard / sent as nudge
+  → Read by Briefing Engine + Nudge Engine + GET /api/events
+  → Displayed in Dashboard
 ```
 
 ### 2. Email Data
 ```
 Gmail API
-  → Gmail Connector (every 15 min via node-cron)
-  → Filter: keywords + sender history → initial flag pass
-  → Claude Haiku: score remaining emails for importance
+  → src/connectors/gmail.js (every 15 min via node-cron)
+  → Filter pass 1: keyword match + known sender → auto-flag
+  → Filter pass 2: remaining emails → Ollama (gemma4:e4b) scores importance
+      POST http://localhost:11434/v1/chat/completions
+      Prompt: "Is this email important or routine? Respond with one word: important or routine."
+      Input: subject + sender + snippet (first 200 chars)
   → Upsert into emails table (is_flagged = true/false)
-  → Read by Briefing Engine + REST API
+  → Read by Briefing Engine + GET /api/emails/flagged
   → Displayed in Dashboard
 ```
 
 ### 3. Morning Briefing
 ```
-node-cron (7:00am daily)
-  → Pull events (today + tomorrow) from SQLite
-  → Pull flagged emails (last 24h) from SQLite
-  → Build structured prompt → Claude Haiku API call
-  → Parse response → store in briefings table
-  → Trigger Web Push notification to browser
-  → Optionally send SMS via Twilio
+node-cron (fires at BRIEFING_TIME, default 07:00 local)
+  → src/engines/briefing.js
+  → Pull all events WHERE start_time BETWEEN now AND now+48h FROM events
+  → Pull all emails WHERE is_flagged=1 AND received_at > now-24h FROM emails
+  → Build prompt (see BRIEF-001 for prompt contract)
+  → POST http://localhost:11434/v1/chat/completions
+      model: OLLAMA_MODEL (default: gemma4:e4b)
+      messages: [system, user]
+  → Parse response text
+  → INSERT into briefings (generated_at, content_raw, content_html)
+  → Send Web Push via src/push/webpush.js
+  → If TWILIO_ENABLED=true: send SMS (truncated to 320 chars)
+  → If Ollama call fails: generate structured fallback (event titles + email subjects), store it
 ```
 
 ### 4. Proactive Nudge
 ```
 node-cron (every 5 min)
-  → Query events starting in 115–125 min (2hr check)
-  → Query events starting in 25–35 min (30min check)
-  → For each candidate:
-      - Was it already nudged? (check nudges table) → skip
-      - Has user opened dashboard in last 30 min? (check settings) → skip
-      - Daily nudge limit reached? (check nudges_sent_today) → skip
-  → Send Web Push notification
-  → Record in nudges table
+  → src/engines/nudge.js
+  → Query: SELECT * FROM events WHERE start_time BETWEEN now+115min AND now+125min (2hr check)
+  → Query: SELECT * FROM events WHERE start_time BETWEEN now+25min AND now+35min (30min check)
+  → For each candidate event:
+      1. SELECT COUNT(*) FROM nudges WHERE event_id=? AND nudge_type=? → skip if already sent
+      2. SELECT value FROM settings WHERE key='last_dashboard_open' → skip if < 30 min ago
+      3. SELECT value FROM settings WHERE key='nudges_sent_today' → skip if >= nudges_per_day
+  → Send Web Push: "You have [title] in 2 hours." / "Starting in 30 minutes: [title]"
+  → INSERT into nudges (event_id, nudge_type, sent_at)
+  → UPDATE settings SET value=value+1 WHERE key='nudges_sent_today'
 ```
 
 ---
@@ -125,7 +199,7 @@ node-cron (every 5 min)
 ### Local-First (No Cloud by Default)
 **Decision:** Everything runs on the user's machine. SQLite over Postgres. Local Express server over a hosted API.
 
-**Why:** Privacy is a core product principle. The user's calendar and email data never leaves their machine unless they explicitly enable cloud sync. Local also means zero hosting costs, zero cold starts, and sub-100ms API responses. For a personal productivity tool used by one person on one network, this is the right tradeoff. Cloud sync can be added later as opt-in.
+**Why:** Privacy is a core product principle. The user's calendar and email data never leaves their machine. Local also means zero hosting costs, zero cold starts, and sub-100ms API responses.
 
 **Tradeoff:** Can't easily share the dashboard from another device. Acceptable for MVP — mobile-responsive web on localhost works fine from any device on the same LAN.
 
@@ -134,7 +208,7 @@ node-cron (every 5 min)
 ### SQLite Over Postgres
 **Decision:** Use SQLite via `better-sqlite3` for all persistent storage.
 
-**Why:** Zero setup. No background database process. Survives machine restarts cleanly. More than fast enough for a single-user app with a few thousand rows. The data model is simple and unlikely to need complex joins or high concurrency. Switching to Postgres later (for the business version) is straightforward — the schema is clean and the queries are simple.
+**Why:** Zero setup. No background database process. Survives machine restarts cleanly. More than fast enough for a single-user app with a few thousand rows. Switching to Postgres later (for the business version) is straightforward.
 
 **Tradeoff:** No multi-user support without significant rework. Acceptable — the personal version is single-user by design.
 
@@ -143,49 +217,85 @@ node-cron (every 5 min)
 ### Read-Only from All Sources
 **Decision:** Pulse never writes to Google Calendar or Gmail. Ever.
 
-**Why:** This is a trust principle, not a technical constraint. Users need to trust that Pulse cannot make mistakes on their behalf — send an email they didn't write, delete an event, or modify their calendar. Read-only access cannot cause harm. Write access, however small, can. The product earns trust by never having write access in the first place.
+**Why:** Trust principle. Read-only access cannot cause harm. Write access, however small, can. The product earns trust by never having write access in the first place.
 
-**Tradeoff:** Can't auto-reply, create reminders in Google Calendar, or archive emails. Acceptable — those features would cross the line into Pulse acting as the user's agent, which is explicitly out of scope.
+**Tradeoff:** Can't auto-reply, create reminders in Google Calendar, or archive emails. Permanent product constraint — not an MVP limitation.
+
+---
+
+### Ollama (Local LLM) for Briefings and Email Scoring
+**Decision:** Use Ollama running locally (port 11434) as the LLM for both morning briefing generation and email importance scoring. Default model: `gemma4:e4b`.
+
+**Why:** Three reasons.
+
+1. **Privacy**: Email content and calendar data never leave the machine. Sending this data to an external API (Anthropic, OpenAI) would violate the local-first privacy principle. Ollama runs on the same hardware as Pulse, so the data flow is entirely local.
+
+2. **Cost**: No per-token API fees. Ollama runs open-source models for free after the initial model pull. At briefing frequency (once daily) plus email scoring (15-minute sync intervals), this is a meaningful cost difference at scale.
+
+3. **Consistency**: Pulse is already local-first for storage and hosting. Using a local LLM makes the entire stack consistent — no external dependencies after initial setup.
+
+**Model choice — `gemma4:e4b`**: Fast inference on Apple Silicon (~30 tok/s on M4), good summarization quality, 4-bit quantized so it fits comfortably alongside other processes (approx 8GB VRAM).
+
+**Ollama API contract**: Pulse calls the OpenAI-compatible endpoint at `http://localhost:11434/v1/chat/completions`. This means swapping models requires only changing `OLLAMA_MODEL` in `.env` — no code changes.
+
+**Tradeoff**: Ollama must be installed and the model must be pulled before Pulse starts. The deploy script (`scripts/start.sh`) checks for this and fails fast with a clear message if Ollama isn't running. If the Ollama call fails at runtime (process down, timeout), Pulse falls back to a structured plain-text summary — it never shows a blank briefing card.
+
+**If you want a more capable model**: Change `OLLAMA_MODEL` to `qwen2.5:14b`. Requires ~16GB VRAM. Better at nuanced reasoning (e.g., detecting implied deadlines in emails). Not required for MVP.
 
 ---
 
 ### Pure HTML/CSS/JS Frontend
 **Decision:** No React, no Vue, no build step. Raw HTML + CSS + vanilla JS.
 
-**Why:** Simplicity and speed. The dashboard is a read-mostly display with minimal interactivity. It doesn't need a component framework. A build step would add complexity with no benefit. Vanilla JS is sufficient and loads instantly. This also makes it trivial to embed in a local server — just `res.sendFile()`.
+**Why:** The dashboard is a read-mostly display with minimal interactivity. No component framework is needed. A build step would add complexity with no benefit. `res.sendFile()` from Express is the entire "deploy."
 
-**Tradeoff:** More manual DOM manipulation code for complex interactions. Acceptable for MVP. If the UI grows significantly, a lightweight framework like Alpine.js can be added without a build step.
-
----
-
-### Claude Haiku for Briefings
-**Decision:** Use Claude Haiku (not GPT-4 or Claude Sonnet) for the briefing engine.
-
-**Why:** Haiku is fast (< 1 second for a briefing), cheap (fractions of a cent per call), and more than capable of summarizing a list of events and emails in plain language. The briefing task does not require deep reasoning — it requires concise, clear summarization. Haiku excels at that. Using a more expensive model would add cost with no quality benefit for this use case.
-
-**Tradeoff:** Less capable for nuanced tasks. If the briefing engine evolves to do more complex reasoning (e.g., "this email looks like a deadline is being missed"), a more powerful model can be dropped in — the prompt/response contract is the same.
+**Tradeoff:** More manual DOM code for complex interactions. Acceptable for MVP.
 
 ---
 
 ### node-cron for Scheduling
-**Decision:** Use `node-cron` for all scheduled jobs (sync, briefing, nudges) rather than OS-level cron or a separate scheduler.
+**Decision:** Use `node-cron` for all scheduled jobs rather than OS-level cron or a separate scheduler.
 
-**Why:** Keeps everything in-process. No additional services to manage. Jobs can access the SQLite connection and shared state directly. Easy to unit-test. `node-cron` supports cron syntax including timezone-aware scheduling.
+**Why:** Keeps everything in-process. Jobs share the SQLite connection and state directly. Timezone-aware cron syntax supported.
 
-**Tradeoff:** Jobs die if the Node.js process dies. Mitigated by running under `pm2` with auto-restart.
+**Tradeoff:** Jobs die if the Node process dies. Mitigated by `pm2` with auto-restart.
+
+---
+
+## Required Environment Variables
+
+| Key | Required | Default | Description |
+|---|---|---|---|
+| `PULSE_PASSWORD` | Yes | — | Dashboard login password |
+| `GOOGLE_CLIENT_ID` | Yes | — | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | Yes | — | Google OAuth client secret |
+| `GOOGLE_REDIRECT_URI` | Yes | `http://localhost:3000/oauth/callback` | OAuth redirect |
+| `SESSION_SECRET` | Yes | — | Express session signing key (random string) |
+| `OLLAMA_BASE_URL` | No | `http://localhost:11434` | Ollama server URL |
+| `OLLAMA_MODEL` | No | `gemma4:e4b` | Model to use for briefings + email scoring |
+| `BRIEFING_TIME` | No | `07:00` | Daily briefing time in local 24h format |
+| `TWILIO_ENABLED` | No | `false` | Enable SMS delivery |
+| `TWILIO_ACCOUNT_SID` | If Twilio | — | Twilio credentials |
+| `TWILIO_AUTH_TOKEN` | If Twilio | — | Twilio credentials |
+| `TWILIO_FROM_NUMBER` | If Twilio | — | Twilio sending number |
+| `TWILIO_TO_NUMBER` | If Twilio | — | User's phone number |
+| `VAPID_PUBLIC_KEY` | Generated | — | Web Push VAPID key (generate with `web-push generate-vapid-keys`) |
+| `VAPID_PRIVATE_KEY` | Generated | — | Web Push VAPID key |
+| `VAPID_EMAIL` | Yes (if push) | — | Contact email for VAPID |
+| `PORT` | No | `3000` | Express server port |
 
 ---
 
 ## Future Scaling Path
 
 ### When to Add Cloud Sync
-When Pulse needs to work across multiple devices (desktop + phone native app), or when the business version requires a shared team brain that multiple users read from. At that point: move from SQLite to Postgres, add a sync API, and keep the local-first mode as an option.
+When Pulse needs to work across multiple devices, or the business version requires shared team context. At that point: move from SQLite to Postgres, add a sync API, keep local-first as opt-in.
 
 ### When to Add Team Features (Business Version)
-After personal v1.0 is stable and used by real people for at least a month. The business version requires multi-user auth, data isolation, role-based briefings, and likely a hosted deployment. None of that is appropriate to build until the core personal experience is proven.
+After personal v1.0 is stable and used by at least one real person for two weeks. Business version requires multi-user auth, data isolation, and role-based briefings. See `docs/BIZ_ARCHITECTURE.md` (created by BIZ-001).
 
 ### When to Build a Native App
-When the web-responsive experience on mobile is clearly insufficient and users are asking for a home screen icon and native push notifications. The first step is a PWA (Progressive Web App) wrapper — no App Store, just an installable web app. Full native (Swift/Kotlin) only if PWA is insufficient.
+When the web-responsive experience on mobile is clearly insufficient. First step: PWA wrapper. Full native only if PWA is insufficient.
 
 ### When to Add More Data Sources
-After Calendar and Gmail are proven reliable and the briefing quality is high. Next candidates: iMessage/SMS (requires Mac-specific tooling), Slack (OAuth + webhook), GitHub (for developer-focused users). Each new source requires an explicit user opt-in and a new connector module. The architecture supports this — each connector is isolated, reads from its source, and writes to a shared SQLite schema.
+After Calendar and Gmail are proven reliable. Next candidates: Slack (OAuth + Events API), GitHub (webhooks or polling). Each connector is isolated — adding one does not touch existing connectors.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
-    "test": "node --experimental-sqlite --test"
+    "test": "node --experimental-sqlite --test",
+    "seed-demo": "node --experimental-sqlite scripts/seed-demo.js"
   },
   "dependencies": {
     "express": "^4.21.2",

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,74 @@
+const POLL_MS = 5 * 60 * 1000;
+
+function fmt(iso) {
+  if (!iso) return "";
+  const d = new Date(iso + "Z");
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+
+async function getJson(path) {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error(`${path}: ${res.status}`);
+  return res.json();
+}
+
+function renderFeed({ events = [], emails = [] }) {
+  const el = document.getElementById("feed");
+  const items = [
+    ...events.map((e) => ({ kind: "ev", when: e.start_time, html: `<span class="tag ev">event</span>${esc(e.title)}<span class="when">${fmt(e.start_time)}${e.location ? " · " + esc(e.location) : ""}</span>` })),
+    ...emails.map((m) => ({ kind: "em", when: m.received_at, html: `<span class="tag em">email</span>${esc(m.subject || "(no subject)")}<span class="when">${esc(m.sender || "")} · ${fmt(m.received_at)}</span>` })),
+  ].sort((a, b) => new Date(a.when) - new Date(b.when));
+
+  if (!items.length) { el.innerHTML = `<li class="muted">Nothing on the feed.</li>`; return; }
+  el.innerHTML = items.map((i) => `<li>${i.html}</li>`).join("");
+}
+
+function renderBriefing({ latest, history = [] }) {
+  const el = document.getElementById("briefing");
+  if (!latest) { el.className = "briefing muted"; el.textContent = "No briefing yet."; }
+  else {
+    el.className = "briefing";
+    el.textContent = latest.content_raw || "(empty briefing)";
+  }
+  const hl = document.getElementById("history-list");
+  hl.innerHTML = history.map((h) => `<li>${fmt(h.generated_at)}</li>`).join("");
+}
+
+function renderStatus({ last_sync, sources, nudges_today }) {
+  const el = document.getElementById("status");
+  const row = (label, ok) => `<li><span><span class="dot ${ok ? "ok" : "bad"}"></span>${label}</span><span>${ok ? "connected" : "not connected"}</span></li>`;
+  el.innerHTML = [
+    row("Calendar", sources.calendar),
+    row("Gmail", sources.gmail),
+    `<li><span>Last sync</span><span>${last_sync ? fmt(last_sync) : "never"}</span></li>`,
+    `<li><span>Nudges today</span><span>${nudges_today}</span></li>`,
+  ].join("");
+
+  const badge = document.getElementById("sync-badge");
+  badge.textContent = last_sync ? `synced ${fmt(last_sync)}` : "no sync yet";
+}
+
+function esc(s) {
+  return String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+async function refresh() {
+  try {
+    const [events, emails, briefings, status] = await Promise.all([
+      getJson("/api/events"),
+      getJson("/api/emails/flagged"),
+      getJson("/api/briefings"),
+      getJson("/api/status"),
+    ]);
+    renderFeed({ events: events.events, emails: emails.emails });
+    renderBriefing(briefings);
+    renderStatus(status);
+  } catch (e) {
+    document.getElementById("sync-badge").textContent = "error";
+    console.error(e);
+  }
+}
+
+refresh();
+setInterval(refresh, POLL_MS);

--- a/public/index.html
+++ b/public/index.html
@@ -1,22 +1,42 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pulse</title>
-  <style>
-    body { margin: 0; font-family: -apple-system, system-ui, sans-serif; background: #0b0d12; color: #e6e8ee; }
-    main { max-width: 720px; margin: 0 auto; padding: 3rem 1.5rem; }
-    h1 { font-weight: 600; letter-spacing: -0.01em; }
-    p { color: #9aa0aa; line-height: 1.5; }
-    code { background: #161922; padding: 0.15rem 0.4rem; border-radius: 4px; }
-  </style>
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-  <main>
+  <header class="topbar">
     <h1>Pulse</h1>
-    <p>Proactive ambient second brain. Dashboard scaffold — panels arrive in later issues.</p>
-    <p>Health: <code>GET /health</code></p>
+    <span id="sync-badge" class="badge">—</span>
+  </header>
+
+  <main class="grid">
+    <section class="panel" id="panel-feed">
+      <h2>Today's Feed</h2>
+      <ul id="feed" class="feed"><li class="muted">Loading…</li></ul>
+    </section>
+
+    <section class="panel" id="panel-briefing">
+      <h2>Morning Briefing</h2>
+      <div id="briefing" class="briefing muted">Loading…</div>
+      <details id="briefing-history">
+        <summary>History</summary>
+        <ul id="history-list"></ul>
+      </details>
+    </section>
+
+    <section class="panel" id="panel-status">
+      <h2>Status</h2>
+      <ul id="status" class="status muted"><li>Loading…</li></ul>
+    </section>
   </main>
+
+  <footer class="foot">
+    <span id="poll-info">refreshes every 5 min</span>
+  </footer>
+
+  <script src="/dashboard.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,138 @@
+:root {
+  --bg: #0e1116;
+  --panel: #161b22;
+  --panel-2: #1c2230;
+  --text: #e6edf3;
+  --muted: #8b949e;
+  --accent: #58a6ff;
+  --warn: #f0883e;
+  --ok: #3fb950;
+  --bad: #f85149;
+  --border: #30363d;
+  --radius: 10px;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  z-index: 1;
+}
+.topbar h1 { font-size: 18px; margin: 0; letter-spacing: 0.5px; }
+.badge {
+  font-size: 12px;
+  color: var(--muted);
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+
+.grid {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+  max-width: 980px;
+  margin: 0 auto;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 760px) {
+  .grid { grid-template-columns: 2fr 1fr; }
+  #panel-status { grid-column: 1 / -1; }
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+}
+.panel h2 {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--muted);
+  margin: 0 0 10px;
+}
+
+.muted { color: var(--muted); }
+
+.feed, .status, #history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.feed li {
+  padding: 9px 0;
+  border-bottom: 1px solid var(--border);
+}
+.feed li:last-child { border-bottom: none; }
+.feed .when {
+  display: block;
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+.feed .tag {
+  display: inline-block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.tag.ev { background: #1f2a3a; color: var(--accent); }
+.tag.em { background: #3a2417; color: var(--warn); }
+
+.briefing {
+  white-space: pre-wrap;
+  font-size: 14px;
+  line-height: 1.5;
+  min-height: 60px;
+}
+
+.status li {
+  display: flex;
+  justify-content: space-between;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+}
+.status li:last-child { border-bottom: none; }
+.dot {
+  display: inline-block;
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  margin-right: 7px;
+  vertical-align: middle;
+}
+.dot.ok { background: var(--ok); }
+.dot.bad { background: var(--bad); }
+
+details { margin-top: 12px; }
+details summary { cursor: pointer; color: var(--muted); font-size: 13px; }
+#history-list li { padding: 5px 0; font-size: 13px; color: var(--muted); }
+
+.foot {
+  text-align: center;
+  color: var(--muted);
+  font-size: 12px;
+  padding: 16px;
+}

--- a/scripts/seed-demo.js
+++ b/scripts/seed-demo.js
@@ -1,0 +1,56 @@
+import { openDb } from "../src/db/index.js";
+
+// Seeds a small set of demo rows so the dashboard renders something
+// before Google OAuth is configured. Safe to re-run (idempotent-ish:
+// uses unique google_id/gmail_id per run via a fixed demo prefix).
+const DEMO_PREFIX = "demo-";
+
+function iso(offsetHours) {
+  return new Date(Date.now() + offsetHours * 3600_000)
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d+Z$/, "");
+}
+
+const db = openDb();
+
+const events = [
+  { gid: DEMO_PREFIX + "ev1", title: "Standup with MJL team", start: 1, end: 1.5, loc: "Zoom" },
+  { gid: DEMO_PREFIX + "ev2", title: "Onsite walk-through — 12 Oak", start: 4, end: 5.5, loc: "12 Oak St" },
+  { gid: DEMO_PREFIX + "ev3", title: "Concepts Loop review", start: 28, end: 29, loc: null },
+];
+const insEvent = db.prepare(
+  `INSERT OR IGNORE INTO events (google_id, title, start_time, end_time, location) VALUES (?, ?, ?, ?, ?)`
+);
+for (const e of events) {
+  insEvent.run(e.gid, e.title, iso(e.start), iso(e.end), e.loc);
+}
+
+const emails = [
+  { gid: DEMO_PREFIX + "em1", sender: "accounts@mjl.com", subject: "Invoice #4421 ready", snippet: "Your invoice for July flooring work is attached…", recv: -2, flagged: 1 },
+  { gid: DEMO_PREFIX + "em2", sender: "ops@openclaw.dev", subject: "Concepts Loop: 3 new concepts", snippet: "Three concepts queued for your review…", recv: -6, flagged: 1 },
+  { gid: DEMO_PREFIX + "em3", sender: "newsletter@x.com", subject: "Weekly digest", snippet: "Top stories this week…", recv: -10, flagged: 0 },
+];
+const insEmail = db.prepare(
+  `INSERT OR IGNORE INTO emails (gmail_id, sender, subject, snippet, received_at, is_flagged, scored_at) VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`
+);
+for (const m of emails) {
+  insEmail.run(m.gid, m.sender, m.subject, m.snippet, iso(m.recv), m.flagged);
+}
+
+const briefing = `PULSE BRIEFING — ${new Date().toLocaleDateString()}
+
+• 3 events today; first up: Standup with MJL team (Zoom, +1h).
+• 2 flagged emails need a look — invoice #4421 and Concepts Loop queue.
+• Onsite walk-through at 12 Oak in the afternoon; leave buffer for travel.
+
+No nudges fired yet. Sources: demo data (Google not connected).`;
+db.prepare(
+  `INSERT INTO briefings (generated_at, content_raw) VALUES (datetime('now'), ?)`
+).run(briefing);
+
+db.prepare(
+  `INSERT OR REPLACE INTO settings (key, value) VALUES ('last_sync', datetime('now'))`
+).run();
+
+console.log("Demo data seeded.");

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -1,0 +1,75 @@
+import { Router } from "express";
+
+export function createApiRouter(getDb) {
+  const router = new Router();
+
+  router.get("/events", (_req, res) => {
+    const db = getDb();
+    const rows = db
+      .prepare(
+        `SELECT id, title, start_time, end_time, location
+         FROM events
+         WHERE start_time >= datetime('now')
+           AND start_time <= datetime('now', '+48 hours')
+         ORDER BY start_time ASC`
+      )
+      .all();
+    res.json({ events: rows });
+  });
+
+  router.get("/emails/flagged", (_req, res) => {
+    const db = getDb();
+    const rows = db
+      .prepare(
+        `SELECT id, sender, subject, snippet, received_at
+         FROM emails
+         WHERE is_flagged = 1
+           AND received_at >= datetime('now', '-24 hours')
+         ORDER BY received_at DESC`
+      )
+      .all();
+    res.json({ emails: rows });
+  });
+
+  router.get("/briefings", (_req, res) => {
+    const db = getDb();
+    const latest = db
+      .prepare(
+        `SELECT id, generated_at, content_raw
+         FROM briefings
+         ORDER BY generated_at DESC
+         LIMIT 1`
+      )
+      .get();
+    const history = db
+      .prepare(
+        `SELECT id, generated_at
+         FROM briefings
+         ORDER BY generated_at DESC
+         LIMIT 10`
+      )
+      .all();
+    res.json({ latest, history });
+  });
+
+  router.get("/status", (_req, res) => {
+    const db = getDb();
+    const get = (key) => db.prepare("SELECT value FROM settings WHERE key = ?").get(key)?.value;
+    const nudgesToday = db
+      .prepare(
+        `SELECT COUNT(*) AS n FROM nudges
+         WHERE date(sent_at) = date('now')`
+      )
+      .get()?.n ?? 0;
+    res.json({
+      last_sync: get("last_sync") ?? null,
+      sources: {
+        calendar: Boolean(get("google_connected")),
+        gmail: Boolean(get("google_connected")),
+      },
+      nudges_today: nudgesToday,
+    });
+  });
+
+  return router;
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,15 +1,23 @@
 import express from "express";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { openDb } from "./db/index.js";
+import { createApiRouter } from "./routes/api.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export function createApp() {
+export function createApp({ db } = {}) {
+  let _db = db;
+  const resolveDb = () => (_db ??= openDb());
+
   const app = express();
+  app.use(express.json());
 
   app.get("/health", (_req, res) => {
     res.json({ status: "ok", ts: new Date().toISOString() });
   });
+
+  app.use("/api", createApiRouter(() => resolveDb()));
 
   app.use(express.static(path.join(__dirname, "..", "public")));
 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { createApp } from "../src/server.js";
+import { MIGRATIONS } from "../src/db/index.js";
+
+function makeTempDb() {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys = ON");
+  db.exec(MIGRATIONS);
+  return db;
+}
+
+function seed(db) {
+  const now = new Date();
+  const iso = (h) => new Date(now.getTime() + h * 3600_000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "");
+  db.prepare(
+    `INSERT INTO events (google_id, title, start_time, end_time, location) VALUES ('g1','Standup',?,?,NULL)`
+  ).run(iso(1), iso(1.5));
+  db.prepare(
+    `INSERT INTO events (google_id, title, start_time, end_time, location) VALUES ('g2','Past',?,?,NULL)`
+  ).run(iso(-5), iso(-4));
+  db.prepare(
+    `INSERT INTO emails (gmail_id, sender, subject, snippet, received_at, is_flagged, scored_at) VALUES ('m1','a@b','Flagged','snip',?,1,datetime('now'))`
+  ).run(iso(-1));
+  db.prepare(
+    `INSERT INTO emails (gmail_id, sender, subject, snippet, received_at, is_flagged, scored_at) VALUES ('m2','a@b','Old','snip',?,1,datetime('now'))`
+  ).run(iso(-30));
+  db.prepare(
+    `INSERT INTO briefings (generated_at, content_raw) VALUES (?, 'hello')`
+  ).run(iso(-3));
+  db.prepare(`INSERT INTO settings (key, value) VALUES ('last_sync', datetime('now'))`).run();
+  db.prepare(`INSERT INTO settings (key, value) VALUES ('google_connected', '1')`).run();
+  db.prepare(`INSERT INTO nudges (event_id, nudge_type, sent_at) VALUES (1, 'two_hour', datetime('now'))`).run();
+}
+
+function start(app) {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => resolve(server));
+  });
+}
+
+async function withServer(fn) {
+  const db = makeTempDb();
+  seed(db);
+  const app = createApp({ db });
+  const server = await start(app);
+  const { port } = server.address();
+  try {
+    await fn(`http://localhost:${port}`);
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+}
+
+test("GET /api/events returns only upcoming within 48h", async () => {
+  await withServer(async (base) => {
+    const res = await fetch(`${base}/api/events`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.events.length, 1);
+    assert.equal(body.events[0].title, "Standup");
+  });
+});
+
+test("GET /api/emails/flagged returns last 24h flagged", async () => {
+  await withServer(async (base) => {
+    const res = await fetch(`${base}/api/emails/flagged`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.emails.length, 1);
+    assert.equal(body.emails[0].subject, "Flagged");
+  });
+});
+
+test("GET /api/briefings returns latest + history", async () => {
+  await withServer(async (base) => {
+    const res = await fetch(`${base}/api/briefings`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.latest.content_raw, "hello");
+    assert.ok(Array.isArray(body.history));
+    assert.equal(body.history.length, 1);
+  });
+});
+
+test("GET /api/status reports sources + nudges today", async () => {
+  await withServer(async (base) => {
+    const res = await fetch(`${base}/api/status`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.sources.calendar, true);
+    assert.equal(body.sources.gmail, true);
+    assert.equal(body.nudges_today, 1);
+    assert.ok(body.last_sync);
+  });
+});

--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -1,9 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
 import { createApp } from "../src/server.js";
+import { MIGRATIONS } from "../src/db/index.js";
+
+function makeTempDb() {
+  const db = new DatabaseSync(":memory:");
+  db.exec(MIGRATIONS);
+  return db;
+}
 
 test("GET /health returns 200 and { status: 'ok' }", async () => {
-  const app = createApp();
+  const app = createApp({ db: makeTempDb() });
   const server = app.listen(0);
   const { port } = server.address();
   try {
@@ -19,7 +27,7 @@ test("GET /health returns 200 and { status: 'ok' }", async () => {
 });
 
 test("static dashboard is served at /", async () => {
-  const app = createApp();
+  const app = createApp({ db: makeTempDb() });
   const server = app.listen(0);
   const { port } = server.address();
   try {


### PR DESCRIPTION
## Summary
- Three-panel dashboard: Today's Feed (events + flagged emails), Morning Briefing (latest + history), Status (sources, last sync, nudges today). Polls /api every 5 min.
- API routes: GET /api/events, /api/emails/flagged, /api/briefings, /api/status.
- scripts/seed-demo.js seeds demo data so the dashboard renders before Google OAuth is configured.
- Tests: 4 new API route tests (hermetic in-memory db); health.test.js now injects a temp db. 39/39 green.
- Also sweeps in pre-existing uncommitted doc edits (BACKLOG.md executable-issue format; ARCHITECTURE.md Ollama instead of Claude Haiku + /api routes).

Closes #22
